### PR TITLE
fix: rename syntax → spec_version in example seed

### DIFF
--- a/examples/seed.yaml
+++ b/examples/seed.yaml
@@ -1,4 +1,4 @@
-syntax: v1
+spec_version: v1
 schema:
   name: example-app
   description: Example application configuration schema


### PR DESCRIPTION
Post-[decree#118](https://github.com/opendecree/decree/pull/130) cleanup. The top-level YAML key `syntax:` was renamed to `spec_version:` in the decree schema/config/seed format. Without this change, `decree seed examples/seed.yaml` against a decree built from main fails with:

> spec_version is required

Generated stubs (`schema_service_pb2.pyi`) still reference the old name in a doc comment — will regenerate on the next decree release bump.

## Test plan
- [ ] `decree seed examples/seed.yaml` against a locally-built decree from main succeeds (manual check recommended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)