### PR TITLE
docs: add PyPI downloads + repostatus alpha badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![PyPI](https://img.shields.io/pypi/v/opendecree)](https://pypi.org/project/opendecree/)
 [![Python](https://img.shields.io/pypi/pyversions/opendecree)](https://pypi.org/project/opendecree/)
 [![Downloads](https://img.shields.io/pypi/dm/opendecree)](https://pypi.org/project/opendecree/)
-[![Coverage](https://img.shields.io/badge/coverage-98%25-brightgreen)](https://github.com/opendecree/decree-python)
 [![License](https://img.shields.io/github/license/opendecree/decree-python)](LICENSE)
 [![Project Status: WIP](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 [![CI](https://github.com/opendecree/decree-python/actions/workflows/ci.yml/badge.svg)](https://github.com/opendecree/decree-python/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/opendecree)](https://pypi.org/project/opendecree/)
 [![Python](https://img.shields.io/pypi/pyversions/opendecree)](https://pypi.org/project/opendecree/)
+[![Downloads](https://img.shields.io/pypi/dm/opendecree)](https://pypi.org/project/opendecree/)
 [![Coverage](https://img.shields.io/badge/coverage-98%25-brightgreen)](https://github.com/opendecree/decree-python)
 [![License](https://img.shields.io/github/license/opendecree/decree-python)](LICENSE)
+[![Project Status: WIP](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 
 Python SDK for [OpenDecree](https://github.com/opendecree/decree) — schema-driven configuration management.
 


### PR DESCRIPTION
## Summary
- Adds PyPI monthly downloads badge and [repostatus.org](https://www.repostatus.org/) **WIP** badge.
- Completes AC for decree-python in opendecree/decree#146.

## Test plan
- [ ] README renders correctly on GitHub
- [ ] Badges link to their targets (PyPI page, repostatus.org/#wip)