### PR TITLE
fix(ci): use underscore input names for first-interaction@v3

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -17,12 +17,12 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             Thanks for opening your first issue! We'll take a look soon.
 
             In the meantime, search [Discussions](https://github.com/opendecree/decree/discussions) for related topics.
-          pr-message: |
+          pr_message: |
             Thanks for your first pull request! We appreciate the contribution.
 
             Before review, please make sure tests pass: `cd sdk && pytest`


### PR DESCRIPTION
## Summary
- v3 of `actions/first-interaction` renamed inputs from hyphens to underscores (`repo_token`, `issue_message`, `pr_message`).
- After the recent v1→v3 dependabot bump, the workflow errored on every PR with `Input required and not supplied: issue_message`.
- Mirrors opendecree/decree#188.

## Test plan
- [x] `action.yml` for v3 confirms underscore input names.
- [ ] Welcome job step no longer errors on next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)