### PR TITLE
fix: derive __version__ from package metadata

### DIFF
--- a/sdk/src/opendecree/__init__.py
+++ b/sdk/src/opendecree/__init__.py
@@ -1,6 +1,8 @@
 """OpenDecree Python SDK — schema-driven configuration management."""
 
-__version__ = "0.1.0"
+from importlib.metadata import version as _pkg_version
+
+__version__ = _pkg_version("opendecree")
 
 SUPPORTED_SERVER_VERSION = ">=0.3.0,<1.0.0"
 PROTO_VERSION = "v1"

--- a/sdk/tests/test_client.py
+++ b/sdk/tests/test_client.py
@@ -17,7 +17,7 @@ class TestConfigClientImport:
         assert hasattr(opendecree, "ConfigClient")
 
     def test_version_constants(self):
-        assert opendecree.__version__ == "0.1.0"
+        assert opendecree.__version__
         assert opendecree.SUPPORTED_SERVER_VERSION == ">=0.3.0,<1.0.0"
         assert opendecree.PROTO_VERSION == "v1"
 

--- a/sdk/tests/test_version.py
+++ b/sdk/tests/test_version.py
@@ -1,10 +1,14 @@
 """Basic tests to verify the package is importable."""
 
+import re
+from importlib.metadata import version as _pkg_version
+
 import opendecree
 
 
 def test_version():
-    assert opendecree.__version__ == "0.1.0"
+    assert opendecree.__version__ == _pkg_version("opendecree")
+    assert re.match(r"^\d+\.\d+\.\d+([abrc]\d+|\.post\d+|\.dev\d+)?$", opendecree.__version__)
 
 
 def test_supported_server_version():


### PR DESCRIPTION
## Summary
- `opendecree.__version__` was hardcoded to `"0.1.0"` since the very first release and never updated. Verified at this morning's v0.3.0a1 publish: PyPI shows 0.3.0a1, but `python -c "import opendecree; print(opendecree.__version__)"` printed `0.1.0`.
- Read the version from `importlib.metadata.version("opendecree")` so it always tracks the installed wheel.
- Tighten the tests so they would have caught this — they previously asserted `== "0.1.0"`, which is why drift went unnoticed.

## Test plan
- [x] `make test` — 171 passed, 97.37% coverage
- [ ] After merge + next release, verify `python -c "import opendecree; print(opendecree.__version__)"` matches the published PyPI version

🤖 Generated with [Claude Code](https://claude.com/claude-code)