### PR TITLE
ci: migrate CodeQL to advanced setup

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,61 @@
+# CodeQL advanced setup. Replaces default-setup once disabled in repo settings.
+# Advanced unlocks paths-ignore (skip generated proto stubs) and workflow pinning.
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "sdk/src/opendecree/_generated/**"
+      - "**/*.md"
+  push:
+    branches: [main]
+  schedule:
+    - cron: "33 7 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config: |
+            paths-ignore:
+              - sdk/src/opendecree/_generated/**
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

- Disables CodeQL default-setup so the advanced workflow takes over
- Adds `paths-ignore` for generated proto stubs (`sdk/src/opendecree/_generated/**`) to avoid false positives on generated code
- Staggered weekly schedule (Monday 07:33 UTC) to avoid resource contention with other repos

## Test plan

- [ ] Verify CodeQL advanced workflow appears under Actions after merge
- [ ] Confirm default-setup is no longer listed under repo Security settings
- [ ] Confirm generated stubs are excluded from analysis results

Closes #23
Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)