### PR TITLE
ci: add Codecov coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,15 @@ jobs:
         run: pip install -e "sdk[dev]"
 
       - name: Run tests with coverage
-        run: cd sdk && pytest --cov --cov-report=term-missing
+        run: cd sdk && pytest --cov --cov-report=term-missing --cov-report=xml:coverage.xml
+
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        # codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
+        with:
+          files: sdk/coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   examples:
     name: Examples

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Downloads](https://img.shields.io/pypi/dm/opendecree)](https://pypi.org/project/opendecree/)
 [![License](https://img.shields.io/github/license/opendecree/decree-python)](LICENSE)
 [![Project Status: WIP](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
+[![codecov](https://codecov.io/gh/opendecree/decree-python/graph/badge.svg)](https://codecov.io/gh/opendecree/decree-python)
 
 Python SDK for [OpenDecree](https://github.com/opendecree/decree) — schema-driven configuration management.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
+    patch:
+      default:
+        target: 80%


### PR DESCRIPTION
## Summary
- Codecov has no coverage data for the Python SDK — this wires up uploads so the dashboard, PR delta comments, and badge all work
- Adds \`--cov-report=xml\` to pytest and uploads \`coverage.xml\` from the Python 3.12 matrix run only (avoids duplicate reports from the 3.11/3.13 runs)
- Adds \`codecov.yml\` enforcing no project regression and ≥80% patch coverage

## Test plan
- [ ] Ensure \`CODECOV_TOKEN\` is set as org-level secret (handled in opendecree/decree#409)
- [ ] Verify coverage upload lands in Codecov dashboard after merge
- [ ] Confirm badge renders in README

Refs opendecree/decree#153

🤖 Generated with [Claude Code](https://claude.com/claude-code)