### PR TITLE
fix(generated): replace sys.path injection with absolute package imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ generate: $(TOOLS_SENTINEL)
 			--mypy_out=$(GEN_DIR) \
 			--mypy_grpc_out=$(GEN_DIR) \
 			$(PROTO_DIR)/centralconfig/v1/*.proto'
+	find $(GEN_DIR) \( -name '*.py' -o -name '*.pyi' \) \
+		-exec sed -i 's/from centralconfig\./from opendecree._generated.centralconfig./g' {} +
 	@echo "Generated stubs in $(GEN_DIR)"
 
 ## lint: Lint with ruff (check + format)

--- a/sdk/src/opendecree/_generated/__init__.py
+++ b/sdk/src/opendecree/_generated/__init__.py
@@ -1,18 +1,1 @@
-"""Generated proto stubs.
-
-The generated code uses absolute imports (e.g., 'from centralconfig.v1 import
-types_pb2') because protoc generates imports relative to the proto root, not
-the Python package structure. We add this directory to sys.path so those
-imports resolve.
-
-TODO: This pollutes sys.path globally. If this causes import collisions,
-consider using a scoped import hook or configuring protoc to generate
-package-relative imports.
-"""
-
-import os
-import sys
-
-_generated_dir = os.path.dirname(__file__)
-if _generated_dir not in sys.path:
-    sys.path.insert(0, _generated_dir)
+"""Generated proto stubs."""

--- a/sdk/src/opendecree/_generated/centralconfig/v1/audit_service_pb2.py
+++ b/sdk/src/opendecree/_generated/centralconfig/v1/audit_service_pb2.py
@@ -22,7 +22,7 @@ _runtime_version.ValidateProtobufRuntimeVersion(
 _sym_db = _symbol_database.Default()
 
 
-from centralconfig.v1 import types_pb2 as centralconfig_dot_v1_dot_types__pb2
+from opendecree._generated.centralconfig.v1 import types_pb2 as centralconfig_dot_v1_dot_types__pb2
 from google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 

--- a/sdk/src/opendecree/_generated/centralconfig/v1/audit_service_pb2.pyi
+++ b/sdk/src/opendecree/_generated/centralconfig/v1/audit_service_pb2.pyi
@@ -3,7 +3,7 @@
 isort:skip_file
 """
 
-from centralconfig.v1 import types_pb2 as _types_pb2
+from opendecree._generated.centralconfig.v1 import types_pb2 as _types_pb2
 from collections import abc as _abc
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message

--- a/sdk/src/opendecree/_generated/centralconfig/v1/audit_service_pb2_grpc.py
+++ b/sdk/src/opendecree/_generated/centralconfig/v1/audit_service_pb2_grpc.py
@@ -3,7 +3,7 @@
 import grpc
 import warnings
 
-from centralconfig.v1 import audit_service_pb2 as centralconfig_dot_v1_dot_audit__service__pb2
+from opendecree._generated.centralconfig.v1 import audit_service_pb2 as centralconfig_dot_v1_dot_audit__service__pb2
 
 GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__

--- a/sdk/src/opendecree/_generated/centralconfig/v1/audit_service_pb2_grpc.pyi
+++ b/sdk/src/opendecree/_generated/centralconfig/v1/audit_service_pb2_grpc.pyi
@@ -3,7 +3,7 @@
 isort:skip_file
 """
 
-from centralconfig.v1 import audit_service_pb2 as _audit_service_pb2
+from opendecree._generated.centralconfig.v1 import audit_service_pb2 as _audit_service_pb2
 from collections import abc as _abc
 from grpc import aio as _aio
 import abc as _abc_1

--- a/sdk/src/opendecree/_generated/centralconfig/v1/config_service_pb2.py
+++ b/sdk/src/opendecree/_generated/centralconfig/v1/config_service_pb2.py
@@ -22,7 +22,7 @@ _runtime_version.ValidateProtobufRuntimeVersion(
 _sym_db = _symbol_database.Default()
 
 
-from centralconfig.v1 import types_pb2 as centralconfig_dot_v1_dot_types__pb2
+from opendecree._generated.centralconfig.v1 import types_pb2 as centralconfig_dot_v1_dot_types__pb2
 from google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
 
 

--- a/sdk/src/opendecree/_generated/centralconfig/v1/config_service_pb2.pyi
+++ b/sdk/src/opendecree/_generated/centralconfig/v1/config_service_pb2.pyi
@@ -3,7 +3,7 @@
 isort:skip_file
 """
 
-from centralconfig.v1 import types_pb2 as _types_pb2
+from opendecree._generated.centralconfig.v1 import types_pb2 as _types_pb2
 from collections import abc as _abc
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message

--- a/sdk/src/opendecree/_generated/centralconfig/v1/config_service_pb2_grpc.py
+++ b/sdk/src/opendecree/_generated/centralconfig/v1/config_service_pb2_grpc.py
@@ -3,7 +3,7 @@
 import grpc
 import warnings
 
-from centralconfig.v1 import config_service_pb2 as centralconfig_dot_v1_dot_config__service__pb2
+from opendecree._generated.centralconfig.v1 import config_service_pb2 as centralconfig_dot_v1_dot_config__service__pb2
 
 GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__

--- a/sdk/src/opendecree/_generated/centralconfig/v1/config_service_pb2_grpc.pyi
+++ b/sdk/src/opendecree/_generated/centralconfig/v1/config_service_pb2_grpc.pyi
@@ -3,7 +3,7 @@
 isort:skip_file
 """
 
-from centralconfig.v1 import config_service_pb2 as _config_service_pb2
+from opendecree._generated.centralconfig.v1 import config_service_pb2 as _config_service_pb2
 from collections import abc as _abc
 from grpc import aio as _aio
 import abc as _abc_1

--- a/sdk/src/opendecree/_generated/centralconfig/v1/schema_service_pb2.py
+++ b/sdk/src/opendecree/_generated/centralconfig/v1/schema_service_pb2.py
@@ -22,7 +22,7 @@ _runtime_version.ValidateProtobufRuntimeVersion(
 _sym_db = _symbol_database.Default()
 
 
-from centralconfig.v1 import types_pb2 as centralconfig_dot_v1_dot_types__pb2
+from opendecree._generated.centralconfig.v1 import types_pb2 as centralconfig_dot_v1_dot_types__pb2
 from google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
 
 

--- a/sdk/src/opendecree/_generated/centralconfig/v1/schema_service_pb2.pyi
+++ b/sdk/src/opendecree/_generated/centralconfig/v1/schema_service_pb2.pyi
@@ -3,7 +3,7 @@
 isort:skip_file
 """
 
-from centralconfig.v1 import types_pb2 as _types_pb2
+from opendecree._generated.centralconfig.v1 import types_pb2 as _types_pb2
 from collections import abc as _abc
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message

--- a/sdk/src/opendecree/_generated/centralconfig/v1/schema_service_pb2_grpc.py
+++ b/sdk/src/opendecree/_generated/centralconfig/v1/schema_service_pb2_grpc.py
@@ -3,7 +3,7 @@
 import grpc
 import warnings
 
-from centralconfig.v1 import schema_service_pb2 as centralconfig_dot_v1_dot_schema__service__pb2
+from opendecree._generated.centralconfig.v1 import schema_service_pb2 as centralconfig_dot_v1_dot_schema__service__pb2
 
 GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__

--- a/sdk/src/opendecree/_generated/centralconfig/v1/schema_service_pb2_grpc.pyi
+++ b/sdk/src/opendecree/_generated/centralconfig/v1/schema_service_pb2_grpc.pyi
@@ -3,7 +3,7 @@
 isort:skip_file
 """
 
-from centralconfig.v1 import schema_service_pb2 as _schema_service_pb2
+from opendecree._generated.centralconfig.v1 import schema_service_pb2 as _schema_service_pb2
 from collections import abc as _abc
 from grpc import aio as _aio
 import abc as _abc_1

--- a/sdk/src/opendecree/_generated/centralconfig/v1/server_service_pb2_grpc.py
+++ b/sdk/src/opendecree/_generated/centralconfig/v1/server_service_pb2_grpc.py
@@ -3,7 +3,7 @@
 import grpc
 import warnings
 
-from centralconfig.v1 import server_service_pb2 as centralconfig_dot_v1_dot_server__service__pb2
+from opendecree._generated.centralconfig.v1 import server_service_pb2 as centralconfig_dot_v1_dot_server__service__pb2
 
 GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__

--- a/sdk/src/opendecree/_generated/centralconfig/v1/server_service_pb2_grpc.pyi
+++ b/sdk/src/opendecree/_generated/centralconfig/v1/server_service_pb2_grpc.pyi
@@ -3,7 +3,7 @@
 isort:skip_file
 """
 
-from centralconfig.v1 import server_service_pb2 as _server_service_pb2
+from opendecree._generated.centralconfig.v1 import server_service_pb2 as _server_service_pb2
 from collections import abc as _abc
 from grpc import aio as _aio
 import abc as _abc_1

--- a/sdk/tests/test_generated_imports.py
+++ b/sdk/tests/test_generated_imports.py
@@ -1,0 +1,34 @@
+"""Verify generated stubs don't pollute sys.path or shadow external packages."""
+
+import sys
+import types
+
+
+def test_no_syspath_pollution():
+    import opendecree  # noqa: F401
+
+    for entry in sys.path:
+        assert "opendecree/_generated" not in entry, (
+            f"sys.path polluted with generated dir: {entry}"
+        )
+
+
+def test_centralconfig_not_top_level_module():
+    import opendecree  # noqa: F401
+
+    assert "centralconfig" not in sys.modules, (
+        "bare 'centralconfig' leaked into sys.modules — import shadowing possible"
+    )
+
+
+def test_no_shadowing_with_external_centralconfig():
+    sentinel = types.ModuleType("centralconfig")
+    sentinel.__version__ = "external"
+    sys.modules.setdefault("centralconfig", sentinel)
+
+    import opendecree  # noqa: F401
+    from opendecree._generated.centralconfig.v1 import types_pb2  # noqa: F401
+
+    assert sys.modules["centralconfig"] is sentinel, (
+        "opendecree import replaced external 'centralconfig' module"
+    )


### PR DESCRIPTION
## Summary

- The generated proto stubs used bare `from centralconfig.v1 import ...` paths and patched `sys.path` at import time to make them resolve, which shadowed any other package named `centralconfig` in the same environment — a PyPI blocker.
- Rewrites all generated imports to the fully-qualified form `from opendecree._generated.centralconfig.v1 import ...` and drops the `sys.path` injection from `_generated/__init__.py`.
- Adds a `sed` post-process step to `make generate` so future regenerations stay clean automatically without manual intervention.

## Test plan

- [x] All 174 existing tests pass with `make test`
- [x] `test_no_syspath_pollution` — verifies `opendecree/_generated` never appears in `sys.path`
- [x] `test_centralconfig_not_top_level_module` — verifies bare `centralconfig` is not injected into `sys.modules`
- [x] `test_no_shadowing_with_external_centralconfig` — pre-installs a sentinel `centralconfig` module and verifies importing opendecree does not replace it

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)