### PR TITLE
fix(retry): don't retry writes on DEADLINE_EXCEEDED by default

### DIFF
--- a/sdk/docs/configuration.md
+++ b/sdk/docs/configuration.md
@@ -117,7 +117,34 @@ client = ConfigClient(
 client = ConfigClient("localhost:9090", retry=None)
 ```
 
-Default: 3 attempts, 0.1s initial backoff, 5s max, 2x multiplier. Only `UNAVAILABLE` and `DEADLINE_EXCEEDED` are retried.
+Default: 3 attempts, 0.1s initial backoff, 5s max, 2x multiplier.
+
+### Read vs. write retry semantics
+
+**Reads** (`get`, `get_all`) retry on both `UNAVAILABLE` and `DEADLINE_EXCEEDED` — reads are
+idempotent so a duplicate is always safe.
+
+**Writes** (`set`, `set_many`, `set_null`) retry only on `UNAVAILABLE` by default.
+`DEADLINE_EXCEEDED` is excluded because the server may have already applied the write before the
+client timed out — retrying without coordination would double-apply the change (duplicate audit
+log entry, version bump).
+
+To opt a write into `DEADLINE_EXCEEDED` retry, pass an `idempotency_key`:
+
+```python
+import uuid
+
+# Only use this when a duplicate apply is harmless for your use case.
+client.set(
+    "tenant-id",
+    "feature_flags.dark_mode",
+    "true",
+    idempotency_key=str(uuid.uuid4()),  # unique per request
+)
+```
+
+Use `idempotency_key` only when the write is genuinely safe to apply more than once — for example,
+setting a field to a known constant value.
 
 ## Timeouts
 

--- a/sdk/src/opendecree/_retry.py
+++ b/sdk/src/opendecree/_retry.py
@@ -42,6 +42,27 @@ class RetryConfig:
     )
 
 
+def write_safe_config(base: RetryConfig | None) -> RetryConfig | None:
+    """Return a retry config safe for non-idempotent writes.
+
+    Strips DEADLINE_EXCEEDED from retryable codes — a timeout does not guarantee
+    the server hasn't already applied the write, so retrying risks double-apply.
+    Returns None when base is None (retry disabled).
+    """
+    if base is None:
+        return None
+    safe_codes = tuple(c for c in base.retryable_codes if c != grpc.StatusCode.DEADLINE_EXCEEDED)
+    if not safe_codes:
+        return None
+    return RetryConfig(
+        max_attempts=base.max_attempts,
+        initial_backoff=base.initial_backoff,
+        max_backoff=base.max_backoff,
+        multiplier=base.multiplier,
+        retryable_codes=safe_codes,
+    )
+
+
 def with_retry(config: RetryConfig | None, fn: Callable[[], T]) -> T:
     """Execute fn with retry on transient gRPC errors (sync)."""
     if config is None:

--- a/sdk/src/opendecree/async_client.py
+++ b/sdk/src/opendecree/async_client.py
@@ -19,7 +19,7 @@ import grpc.aio
 from opendecree._channel import create_aio_channel
 from opendecree._compat import async_fetch_server_version, check_version_compatible
 from opendecree._interceptors import _build_metadata
-from opendecree._retry import RetryConfig, async_with_retry
+from opendecree._retry import RetryConfig, async_with_retry, write_safe_config
 from opendecree._stubs import (
     ensure_stubs,
     make_string_typed_value,
@@ -227,7 +227,14 @@ class AsyncConfigClient:
         except grpc.aio.AioRpcError as e:
             raise map_grpc_error(e) from e
 
-    async def set(self, tenant_id: str, field_path: str, value: str) -> None:
+    async def set(
+        self,
+        tenant_id: str,
+        field_path: str,
+        value: str,
+        *,
+        idempotency_key: str | None = None,
+    ) -> None:
         """Set a config value.
 
         The value is sent as a string — the server coerces it to the
@@ -237,12 +244,19 @@ class AsyncConfigClient:
             tenant_id: Tenant UUID.
             field_path: Dot-separated field path (e.g., ``"payments.fee"``).
             value: The value as a string.
+            idempotency_key: When provided, the request is retried on
+                ``DEADLINE_EXCEEDED`` in addition to ``UNAVAILABLE``. Use only
+                when the write is safe to apply more than once (e.g., the value
+                is a known constant and a duplicate apply is harmless). Without
+                this key, writes are only retried on ``UNAVAILABLE`` to avoid
+                double-applying after a server-side timeout.
 
         Raises:
             NotFoundError: If the field does not exist in the schema.
             LockedError: If the field is locked.
             InvalidArgumentError: If the value fails validation.
         """
+        retry_cfg = self._retry if idempotency_key is not None else write_safe_config(self._retry)
 
         async def _call() -> None:
             await self._stub.SetField(
@@ -256,7 +270,7 @@ class AsyncConfigClient:
             )
 
         try:
-            await async_with_retry(self._retry, _call)
+            await async_with_retry(retry_cfg, _call)
         except grpc.aio.AioRpcError as e:
             raise map_grpc_error(e) from e
 
@@ -266,6 +280,7 @@ class AsyncConfigClient:
         values: dict[str, str],
         *,
         description: str = "",
+        idempotency_key: str | None = None,
     ) -> None:
         """Atomically set multiple config values.
 
@@ -273,12 +288,16 @@ class AsyncConfigClient:
             tenant_id: Tenant UUID.
             values: Dict mapping field paths to string values.
             description: Optional description for the audit log.
+            idempotency_key: When provided, the request is retried on
+                ``DEADLINE_EXCEEDED`` in addition to ``UNAVAILABLE``. See
+                ``set()`` for details on retry semantics.
 
         Raises:
             NotFoundError: If a field does not exist in the schema.
             LockedError: If any field is locked.
             InvalidArgumentError: If any value fails validation.
         """
+        retry_cfg = self._retry if idempotency_key is not None else write_safe_config(self._retry)
 
         async def _call() -> None:
             updates = [
@@ -299,21 +318,31 @@ class AsyncConfigClient:
             )
 
         try:
-            await async_with_retry(self._retry, _call)
+            await async_with_retry(retry_cfg, _call)
         except grpc.aio.AioRpcError as e:
             raise map_grpc_error(e) from e
 
-    async def set_null(self, tenant_id: str, field_path: str) -> None:
+    async def set_null(
+        self,
+        tenant_id: str,
+        field_path: str,
+        *,
+        idempotency_key: str | None = None,
+    ) -> None:
         """Set a config field to null.
 
         Args:
             tenant_id: Tenant UUID.
             field_path: Dot-separated field path.
+            idempotency_key: When provided, the request is retried on
+                ``DEADLINE_EXCEEDED`` in addition to ``UNAVAILABLE``. See
+                ``set()`` for details on retry semantics.
 
         Raises:
             NotFoundError: If the field does not exist in the schema.
             LockedError: If the field is locked.
         """
+        retry_cfg = self._retry if idempotency_key is not None else write_safe_config(self._retry)
 
         async def _call() -> None:
             await self._stub.SetField(
@@ -327,7 +356,7 @@ class AsyncConfigClient:
             )
 
         try:
-            await async_with_retry(self._retry, _call)
+            await async_with_retry(retry_cfg, _call)
         except grpc.aio.AioRpcError as e:
             raise map_grpc_error(e) from e
 

--- a/sdk/src/opendecree/client.py
+++ b/sdk/src/opendecree/client.py
@@ -22,7 +22,7 @@ import grpc
 from opendecree._channel import create_channel
 from opendecree._compat import check_version_compatible, fetch_server_version
 from opendecree._interceptors import AuthInterceptor, _build_metadata
-from opendecree._retry import RetryConfig, with_retry
+from opendecree._retry import RetryConfig, with_retry, write_safe_config
 from opendecree._stubs import (
     ensure_stubs,
     make_string_typed_value,
@@ -229,7 +229,14 @@ class ConfigClient:
         except grpc.RpcError as e:
             raise map_grpc_error(e) from e
 
-    def set(self, tenant_id: str, field_path: str, value: str) -> None:
+    def set(
+        self,
+        tenant_id: str,
+        field_path: str,
+        value: str,
+        *,
+        idempotency_key: str | None = None,
+    ) -> None:
         """Set a config value.
 
         The value is sent as a string — the server coerces it to the
@@ -239,12 +246,19 @@ class ConfigClient:
             tenant_id: Tenant UUID.
             field_path: Dot-separated field path (e.g., ``"payments.fee"``).
             value: The value as a string.
+            idempotency_key: When provided, the request is retried on
+                ``DEADLINE_EXCEEDED`` in addition to ``UNAVAILABLE``. Use only
+                when the write is safe to apply more than once (e.g., the value
+                is a known constant and a duplicate apply is harmless). Without
+                this key, writes are only retried on ``UNAVAILABLE`` to avoid
+                double-applying after a server-side timeout.
 
         Raises:
             NotFoundError: If the field does not exist in the schema.
             LockedError: If the field is locked.
             InvalidArgumentError: If the value fails validation.
         """
+        retry_cfg = self._retry if idempotency_key is not None else write_safe_config(self._retry)
 
         def _call() -> None:
             self._stub.SetField(
@@ -257,7 +271,7 @@ class ConfigClient:
             )
 
         try:
-            with_retry(self._retry, _call)
+            with_retry(retry_cfg, _call)
         except grpc.RpcError as e:
             raise map_grpc_error(e) from e
 
@@ -267,6 +281,7 @@ class ConfigClient:
         values: dict[str, str],
         *,
         description: str = "",
+        idempotency_key: str | None = None,
     ) -> None:
         """Atomically set multiple config values.
 
@@ -274,12 +289,16 @@ class ConfigClient:
             tenant_id: Tenant UUID.
             values: Dict mapping field paths to string values.
             description: Optional description for the audit log.
+            idempotency_key: When provided, the request is retried on
+                ``DEADLINE_EXCEEDED`` in addition to ``UNAVAILABLE``. See
+                ``set()`` for details on retry semantics.
 
         Raises:
             NotFoundError: If a field does not exist in the schema.
             LockedError: If any field is locked.
             InvalidArgumentError: If any value fails validation.
         """
+        retry_cfg = self._retry if idempotency_key is not None else write_safe_config(self._retry)
 
         def _call() -> None:
             updates = [
@@ -299,21 +318,31 @@ class ConfigClient:
             )
 
         try:
-            with_retry(self._retry, _call)
+            with_retry(retry_cfg, _call)
         except grpc.RpcError as e:
             raise map_grpc_error(e) from e
 
-    def set_null(self, tenant_id: str, field_path: str) -> None:
+    def set_null(
+        self,
+        tenant_id: str,
+        field_path: str,
+        *,
+        idempotency_key: str | None = None,
+    ) -> None:
         """Set a config field to null.
 
         Args:
             tenant_id: Tenant UUID.
             field_path: Dot-separated field path.
+            idempotency_key: When provided, the request is retried on
+                ``DEADLINE_EXCEEDED`` in addition to ``UNAVAILABLE``. See
+                ``set()`` for details on retry semantics.
 
         Raises:
             NotFoundError: If the field does not exist in the schema.
             LockedError: If the field is locked.
         """
+        retry_cfg = self._retry if idempotency_key is not None else write_safe_config(self._retry)
 
         def _call() -> None:
             self._stub.SetField(
@@ -326,7 +355,7 @@ class ConfigClient:
             )
 
         try:
-            with_retry(self._retry, _call)
+            with_retry(retry_cfg, _call)
         except grpc.RpcError as e:
             raise map_grpc_error(e) from e
 

--- a/sdk/tests/test_async_client.py
+++ b/sdk/tests/test_async_client.py
@@ -7,7 +7,7 @@ import grpc.aio
 import pytest
 
 from opendecree.async_client import AsyncConfigClient
-from opendecree.errors import NotFoundError, UnavailableError
+from opendecree.errors import DecreeError, NotFoundError, UnavailableError
 from tests.conftest import FakeRpcError
 
 
@@ -186,6 +186,53 @@ class TestAsyncConfigClientUnit:
 
         with pytest.raises(UnavailableError):
             await client.set_null("t1", "payments.fee")
+
+    @pytest.mark.asyncio
+    async def test_set_does_not_retry_on_deadline_exceeded(self):
+        client = self._make_client()
+        err = FakeRpcError(grpc.StatusCode.DEADLINE_EXCEEDED)
+        client._stub.SetField = AsyncMock(side_effect=err)
+
+        with patch("opendecree._retry.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(DecreeError):
+                await client.set("t1", "payments.fee", "0.5%")
+
+        client._stub.SetField.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_set_retries_on_deadline_exceeded_with_idempotency_key(self):
+        client = self._make_client()
+        err = FakeRpcError(grpc.StatusCode.DEADLINE_EXCEEDED)
+        client._stub.SetField = AsyncMock(side_effect=[err, None])
+
+        with patch("opendecree._retry.asyncio.sleep", new_callable=AsyncMock):
+            await client.set("t1", "payments.fee", "0.5%", idempotency_key="idem-1")
+
+        assert client._stub.SetField.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_set_many_does_not_retry_on_deadline_exceeded(self):
+        client = self._make_client()
+        err = FakeRpcError(grpc.StatusCode.DEADLINE_EXCEEDED)
+        client._stub.SetFields = AsyncMock(side_effect=err)
+
+        with patch("opendecree._retry.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(DecreeError):
+                await client.set_many("t1", {"a": "1"})
+
+        client._stub.SetFields.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_set_null_does_not_retry_on_deadline_exceeded(self):
+        client = self._make_client()
+        err = FakeRpcError(grpc.StatusCode.DEADLINE_EXCEEDED)
+        client._stub.SetField = AsyncMock(side_effect=err)
+
+        with patch("opendecree._retry.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(DecreeError):
+                await client.set_null("t1", "payments.fee")
+
+        client._stub.SetField.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_context_manager(self):

--- a/sdk/tests/test_client.py
+++ b/sdk/tests/test_client.py
@@ -6,7 +6,7 @@ import grpc
 import pytest
 
 import opendecree
-from opendecree.errors import NotFoundError, UnavailableError
+from opendecree.errors import DecreeError, NotFoundError, UnavailableError
 from tests.conftest import FakeRpcError
 
 
@@ -187,6 +187,49 @@ class TestConfigClientUnit:
 
         with pytest.raises(UnavailableError):
             client.set_null("t1", "payments.fee")
+
+    def test_set_does_not_retry_on_deadline_exceeded(self):
+        client = self._make_client()
+        err = FakeRpcError(grpc.StatusCode.DEADLINE_EXCEEDED)
+        client._stub.SetField.side_effect = err
+
+        with patch("opendecree._retry.time.sleep"):
+            with pytest.raises(DecreeError):
+                client.set("t1", "payments.fee", "0.5%")
+
+        client._stub.SetField.assert_called_once()
+
+    def test_set_retries_on_deadline_exceeded_with_idempotency_key(self):
+        client = self._make_client()
+        err = FakeRpcError(grpc.StatusCode.DEADLINE_EXCEEDED)
+        client._stub.SetField.side_effect = [err, MagicMock()]
+
+        with patch("opendecree._retry.time.sleep"):
+            client.set("t1", "payments.fee", "0.5%", idempotency_key="idem-1")
+
+        assert client._stub.SetField.call_count == 2
+
+    def test_set_many_does_not_retry_on_deadline_exceeded(self):
+        client = self._make_client()
+        err = FakeRpcError(grpc.StatusCode.DEADLINE_EXCEEDED)
+        client._stub.SetFields.side_effect = err
+
+        with patch("opendecree._retry.time.sleep"):
+            with pytest.raises(DecreeError):
+                client.set_many("t1", {"a": "1"})
+
+        client._stub.SetFields.assert_called_once()
+
+    def test_set_null_does_not_retry_on_deadline_exceeded(self):
+        client = self._make_client()
+        err = FakeRpcError(grpc.StatusCode.DEADLINE_EXCEEDED)
+        client._stub.SetField.side_effect = err
+
+        with patch("opendecree._retry.time.sleep"):
+            with pytest.raises(DecreeError):
+                client.set_null("t1", "payments.fee")
+
+        client._stub.SetField.assert_called_once()
 
     def test_no_interceptor_when_no_metadata(self):
         """Client with no subject/token/role skips interceptor (line 69)."""

--- a/sdk/tests/test_retry.py
+++ b/sdk/tests/test_retry.py
@@ -6,7 +6,7 @@ import grpc
 import grpc.aio
 import pytest
 
-from opendecree._retry import RetryConfig, async_with_retry, with_retry
+from opendecree._retry import RetryConfig, async_with_retry, with_retry, write_safe_config
 from tests.conftest import FakeRpcError
 
 
@@ -64,6 +64,27 @@ def test_retry_config_defaults():
     assert cfg.multiplier == 2.0
     assert grpc.StatusCode.UNAVAILABLE in cfg.retryable_codes
     assert grpc.StatusCode.DEADLINE_EXCEEDED in cfg.retryable_codes
+
+
+def test_write_safe_config_strips_deadline_exceeded():
+    base = RetryConfig()
+    safe = write_safe_config(base)
+    assert safe is not None
+    assert grpc.StatusCode.UNAVAILABLE in safe.retryable_codes
+    assert grpc.StatusCode.DEADLINE_EXCEEDED not in safe.retryable_codes
+    assert safe.max_attempts == base.max_attempts
+    assert safe.initial_backoff == base.initial_backoff
+    assert safe.max_backoff == base.max_backoff
+    assert safe.multiplier == base.multiplier
+
+
+def test_write_safe_config_none_passthrough():
+    assert write_safe_config(None) is None
+
+
+def test_write_safe_config_all_codes_removed_returns_none():
+    cfg = RetryConfig(retryable_codes=(grpc.StatusCode.DEADLINE_EXCEEDED,))
+    assert write_safe_config(cfg) is None
 
 
 # --- Async retry ---


### PR DESCRIPTION
## Summary

- `set`, `set_many`, and `set_null` were retried on `DEADLINE_EXCEEDED`, which risks double-applying a write that the server had already processed before the client timed out (duplicate audit log entry, extra version bump).
- Adds `write_safe_config()` to strip `DEADLINE_EXCEEDED` from retryable codes for writes. Reads remain unaffected — they are idempotent and safe to retry on either `UNAVAILABLE` or `DEADLINE_EXCEEDED`.
- Adds an `idempotency_key` keyword argument to all three write methods; callers who know their write is safe to repeat can pass a key to opt back into full retry.

## Test plan

- `test_retry.py`: `write_safe_config` strips `DEADLINE_EXCEEDED`, passes through `None`, returns `None` when no codes remain.
- `test_client.py`: writes do not retry on `DEADLINE_EXCEEDED` by default; with `idempotency_key`, `set` retries correctly.
- `test_async_client.py`: same coverage for the async client.
- All 185 tests pass at 97.67% coverage (above the 95% floor).

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)