### PR TITLE
fix(watcher): cancel gRPC stream in stop() to prevent thread leak

### DIFF
--- a/sdk/src/opendecree/watcher.py
+++ b/sdk/src/opendecree/watcher.py
@@ -148,6 +148,7 @@ class ConfigWatcher:
         self._timeout = timeout
         self._fields: dict[str, WatchedField] = {}  # type: ignore[type-arg]
         self._thread: threading.Thread | None = None
+        self._stream: grpc.Future | None = None
         self._stop_event = threading.Event()
 
     def field(self, path: str, type_: type[T], *, default: T) -> WatchedField[T]:
@@ -184,6 +185,8 @@ class ConfigWatcher:
     def stop(self) -> None:
         """Stop watching and clean up the background thread."""
         self._stop_event.set()
+        if self._stream is not None:
+            self._stream.cancel()
         if self._thread is not None:
             self._thread.join(timeout=5.0)
             self._thread = None
@@ -215,7 +218,7 @@ class ConfigWatcher:
 
         while not self._stop_event.is_set():
             try:
-                stream = self._stub.Subscribe(
+                self._stream = self._stub.Subscribe(
                     self._pb2.SubscribeRequest(
                         tenant_id=self._tenant_id,
                         field_paths=field_paths,
@@ -223,10 +226,12 @@ class ConfigWatcher:
                 )
                 backoff = _RECONNECT_INITIAL  # reset on successful connect
 
-                for response in stream:
+                for response in self._stream:
                     if self._stop_event.is_set():
                         return
                     self._process_change(response.change)
+
+                self._stream = None
 
             except grpc.RpcError as e:
                 if self._stop_event.is_set():

--- a/sdk/tests/test_watcher.py
+++ b/sdk/tests/test_watcher.py
@@ -264,3 +264,41 @@ class TestConfigWatcher:
 
         # Thread should have exited on its own due to non-retryable error.
         assert w._thread is None
+
+    def test_stop_cancels_stream_and_joins_thread(self):
+        """stop() cancels the gRPC stream so the background thread exits cleanly."""
+        import threading
+
+        w = self._make_watcher()
+        w.field("fee", float, default=0.0)
+
+        # A blocking iterator that only unblocks when cancel() is called.
+        cancelled = threading.Event()
+
+        class _BlockingIter:
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                # Block until cancelled.
+                cancelled.wait(timeout=10.0)
+                raise StopIteration
+
+            def cancel(self):
+                cancelled.set()
+
+        blocking_stream = _BlockingIter()
+        w._stub.Subscribe.return_value = blocking_stream
+
+        w.start()
+        time.sleep(0.1)  # let the thread reach the blocking iterator
+
+        thread_ref = w._thread
+        assert thread_ref is not None
+        assert thread_ref.is_alive()
+
+        w.stop()
+
+        # Thread must have joined within the timeout.
+        assert not thread_ref.is_alive()
+        assert w._thread is None


### PR DESCRIPTION
## Summary

- `watcher.stop()` joined the background thread but never cancelled the active gRPC stream, so the thread blocked indefinitely inside the `Subscribe` iterator and only exited at process shutdown.
- Storing the live stream as `self._stream` and calling `self._stream.cancel()` before `thread.join()` unblocks the iterator immediately and lets the thread exit cleanly within the timeout.

## Test plan

- [x] New regression test `test_stop_cancels_stream_and_joins_thread` — uses a blocking iterator that only unblocks on `cancel()`, verifies the thread is no longer alive after `stop()` returns.
- [x] All 186 existing tests pass.
- [x] Coverage at 97.69% (above 95% threshold).
- [x] `make lint` and `make test` clean.

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)