### PR TITLE
fix(packaging): include py.typed and .pyi stubs in wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,45 @@ jobs:
           python -m py_compile examples/error-handling/main.py
           python -m py_compile examples/setup.py
 
+  wheel-check:
+    name: Wheel contents
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Build wheel
+        run: |
+          pip install build
+          python -m build sdk/ --wheel --outdir /tmp/dist
+
+      - name: Assert py.typed present
+        run: |
+          pip install zipfile36
+          python - <<'EOF'
+          import zipfile, glob, sys
+          wheels = glob.glob("/tmp/dist/*.whl")
+          assert wheels, "no wheel found"
+          with zipfile.ZipFile(wheels[0]) as whl:
+              names = whl.namelist()
+          found = [n for n in names if n.endswith("py.typed")]
+          if not found:
+              print("FAIL: py.typed missing from wheel"); print("\n".join(names)); sys.exit(1)
+          print(f"OK: {found[0]}")
+          EOF
+
   check:
     name: CI check
     if: always()
-    needs: [lint, typecheck, test, examples]
+    needs: [lint, typecheck, test, examples, wheel-check]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -68,6 +68,10 @@ async with AsyncConfigClient("localhost:9090", subject="myapp") as client:
 
 For detailed concepts (schemas, typed values, versioning, auth), see the [main OpenDecree docs](https://github.com/opendecree/decree).
 
+## Typing
+
+This package is fully typed. It ships a `py.typed` marker and `.pyi` stub files for the generated gRPC layer, so mypy, pyright, and similar tools work without additional configuration.
+
 ## Requirements
 
 - Python 3.11+

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -47,6 +47,9 @@ Issues = "https://github.com/opendecree/decree-python/issues"
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+opendecree = ["py.typed", "_generated/**/*.pyi"]
+
 [tool.ruff]
 target-version = "py311"
 line-length = 100


### PR DESCRIPTION
## Summary

- The wheel was missing `py.typed` and the generated `.pyi` stubs because `[tool.setuptools.package-data]` was not declared — silently breaking the `Typing :: Typed` classifier shipped in the metadata.
- Adds the package-data declaration so both the marker file and all gRPC stub files are included in every wheel build.
- Adds a CI `wheel-check` job that builds the wheel and asserts `py.typed` is present, preventing regression.

## Test plan

- [ ] CI `wheel-check` job passes — wheel contains `py.typed`
- [ ] All existing CI jobs (lint, typecheck, test, examples) remain green
- [ ] `Typing :: Typed` classifier is now accurately reflected in the distributed wheel

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)