### PR TITLE
fix(async-watcher): forward auth metadata to GetConfig and Subscribe

### DIFF
--- a/sdk/src/opendecree/async_client.py
+++ b/sdk/src/opendecree/async_client.py
@@ -373,4 +373,4 @@ class AsyncConfigClient:
         """
         from opendecree.async_watcher import AsyncConfigWatcher
 
-        return AsyncConfigWatcher(self._stub, self._pb2, tenant_id, self._timeout)
+        return AsyncConfigWatcher(self._stub, self._pb2, tenant_id, self._timeout, self._metadata())

--- a/sdk/src/opendecree/async_watcher.py
+++ b/sdk/src/opendecree/async_watcher.py
@@ -129,11 +129,19 @@ class AsyncConfigWatcher:
     auto-starts on enter, auto-stops on exit.
     """
 
-    def __init__(self, stub: Any, pb2: Any, tenant_id: str, timeout: float) -> None:
+    def __init__(
+        self,
+        stub: Any,
+        pb2: Any,
+        tenant_id: str,
+        timeout: float,
+        metadata: list[tuple[str, str]] | None = None,
+    ) -> None:
         self._stub = stub
         self._pb2 = pb2
         self._tenant_id = tenant_id
         self._timeout = timeout
+        self._metadata: list[tuple[str, str]] = metadata or []
         self._fields: dict[str, AsyncWatchedField] = {}  # type: ignore[type-arg]
         self._task: asyncio.Task | None = None  # type: ignore[type-arg]
         self._stopped = False
@@ -193,6 +201,7 @@ class AsyncConfigWatcher:
         resp = await self._stub.GetConfig(
             self._pb2.GetConfigRequest(tenant_id=self._tenant_id),
             timeout=self._timeout,
+            metadata=self._metadata,
         )
         all_values = process_get_all_response(resp)
         for path, watched in self._fields.items():
@@ -211,6 +220,7 @@ class AsyncConfigWatcher:
                         tenant_id=self._tenant_id,
                         field_paths=field_paths,
                     ),
+                    metadata=self._metadata,
                 )
                 backoff = _RECONNECT_INITIAL
 

--- a/sdk/tests/test_async_watcher.py
+++ b/sdk/tests/test_async_watcher.py
@@ -270,3 +270,35 @@ class TestAsyncConfigWatcher:
         assert w._task is not None
         assert w._task.done()
         await w.stop()
+
+    @pytest.mark.asyncio
+    async def test_auth_metadata_forwarded(self):
+        """metadata= is passed to both GetConfig and Subscribe."""
+        stub = MagicMock()
+        pb2 = MagicMock()
+
+        mock_resp = MagicMock()
+        mock_resp.config.values = []
+        stub.GetConfig = AsyncMock(return_value=mock_resp)
+
+        auth_meta = [("x-subject", "svc"), ("x-role", "superadmin")]
+        w = AsyncConfigWatcher(stub, pb2, "t1", timeout=5.0, metadata=auth_meta)
+        w.field("fee", float, default=0.0)
+
+        async def empty_stream():
+            return
+            yield
+
+        stub.Subscribe.return_value = empty_stream()
+
+        await w.start()
+        await asyncio.sleep(0.05)
+        await w.stop()
+
+        stub.GetConfig.assert_awaited_once()
+        _, get_kwargs = stub.GetConfig.call_args
+        assert get_kwargs.get("metadata") == auth_meta
+
+        stub.Subscribe.assert_called_once()
+        _, sub_kwargs = stub.Subscribe.call_args
+        assert sub_kwargs.get("metadata") == auth_meta


### PR DESCRIPTION
## Summary

- `AsyncConfigWatcher` bypassed the per-call auth metadata injection that `AsyncConfigClient` uses for all unary calls, causing auth-enabled servers to reject the `Subscribe` stream (and the initial `GetConfig` snapshot) with `UNAUTHENTICATED`.
- Added a `metadata` parameter to `AsyncConfigWatcher.__init__` and threaded it through both `_load_snapshot` and `_subscribe_loop`.
- Updated `AsyncConfigClient.watch()` to pass `self._metadata()` when constructing the watcher.

## Test plan

- [x] Added `test_auth_metadata_forwarded` — asserts that both `GetConfig` and `Subscribe` receive the correct metadata tuples when the watcher is constructed with auth metadata.
- [x] All 187 existing tests pass (`make test`, 97.69% coverage).

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)