### PR TITLE
Fix sync server version API consistency

### DIFF
--- a/examples/quickstart/main.py
+++ b/examples/quickstart/main.py
@@ -20,6 +20,9 @@ def main() -> None:
 
     # Context manager closes the gRPC channel automatically.
     with ConfigClient("localhost:9090", subject="quickstart-example") as client:
+        server_version = client.get_server_version()
+        print(f"server.version:    {server_version.version}")
+
         # get() returns str by default.
         name = client.get(tenant_id, "app.name")
         print(f"app.name:          {name}")

--- a/sdk/docs/async.md
+++ b/sdk/docs/async.md
@@ -8,6 +8,9 @@ The SDK provides async equivalents for all sync APIs, built on `grpc.aio`.
 from opendecree import AsyncConfigClient
 
 async with AsyncConfigClient("localhost:9090", subject="myapp") as client:
+    # Server version
+    version = await client.get_server_version()
+
     # Typed gets (same overload pattern as sync)
     fee = await client.get("tenant-id", "payments.fee")              # → str
     retries = await client.get("tenant-id", "payments.retries", int) # → int

--- a/sdk/docs/configuration.md
+++ b/sdk/docs/configuration.md
@@ -156,6 +156,28 @@ client = ConfigClient("localhost:9090", timeout=30.0)
 
 Default: 10 seconds.
 
+## Server version
+
+Fetch the server version explicitly with `get_server_version()`. The value is cached after the
+first call.
+
+```python
+with ConfigClient("localhost:9090", subject="myapp") as client:
+    version = client.get_server_version()
+    print(version.version)
+```
+
+For async clients, await the same method:
+
+```python
+async with AsyncConfigClient("localhost:9090", subject="myapp") as client:
+    version = await client.get_server_version()
+    print(version.version)
+```
+
+The sync-only `server_version` property is deprecated for one release. Use
+`get_server_version()` for both sync and async clients.
+
 ## Error types
 
 All exceptions inherit from `DecreeError`:

--- a/sdk/src/opendecree/client.py
+++ b/sdk/src/opendecree/client.py
@@ -11,6 +11,7 @@ All writes send string values — the server coerces to the schema-defined type.
 
 from __future__ import annotations
 
+import warnings
 from datetime import timedelta
 from typing import TYPE_CHECKING, overload
 
@@ -108,9 +109,8 @@ class ConfigClient:
     def __exit__(self, *exc: object) -> None:
         self.close()
 
-    @property
-    def server_version(self) -> ServerVersion:
-        """The server's version, fetched once and cached.
+    def get_server_version(self) -> ServerVersion:
+        """Fetch the server's version, cached after first call.
 
         Returns:
             ServerVersion with version and commit strings.
@@ -124,6 +124,20 @@ class ConfigClient:
             )
         return self._server_version
 
+    @property
+    def server_version(self) -> ServerVersion:
+        """The server's version, fetched once and cached.
+
+        Deprecated:
+            Use ``get_server_version()`` instead.
+        """
+        warnings.warn(
+            "ConfigClient.server_version is deprecated; use get_server_version() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_server_version()
+
     def check_compatibility(self) -> None:
         """Check that the server version is compatible with this SDK.
 
@@ -135,7 +149,7 @@ class ConfigClient:
                 supported range.
             UnavailableError: If the server is unreachable.
         """
-        check_version_compatible(self.server_version.version)
+        check_version_compatible(self.get_server_version().version)
 
     # --- get() with @overload for type safety ---
 

--- a/sdk/tests/test_compat.py
+++ b/sdk/tests/test_compat.py
@@ -126,11 +126,11 @@ async def test_async_fetch_server_version():
     assert sv == ServerVersion(version="0.3.1", commit="abc123")
 
 
-# --- ConfigClient.server_version + check_compatibility ---
+# --- ConfigClient.get_server_version + check_compatibility ---
 
 
-def test_client_server_version_cached():
-    """server_version property fetches once, returns cached."""
+def test_client_get_server_version_cached():
+    """get_server_version() fetches once, returns cached."""
     with patch("opendecree.client.create_channel"):
         from opendecree import ConfigClient
 
@@ -147,12 +147,41 @@ def test_client_server_version_cached():
         client._server_version = None
 
         # First call fetches
-        v1 = client.server_version
+        v1 = client.get_server_version()
         assert v1.version == "0.3.1"
         assert mock_stub.GetServerInfo.call_count == 1
 
         # Second call returns cached
-        v2 = client.server_version
+        v2 = client.get_server_version()
+        assert v2 is v1
+        assert mock_stub.GetServerInfo.call_count == 1
+
+
+def test_client_server_version_property_deprecated():
+    with patch("opendecree.client.create_channel"):
+        from opendecree import ConfigClient
+
+        client = ConfigClient.__new__(ConfigClient)
+        client._timeout = 5.0
+
+        mock_stub = MagicMock()
+        resp = MagicMock()
+        resp.version = "0.3.1"
+        resp.commit = "abc123"
+        mock_stub.GetServerInfo.return_value = resp
+        client._version_stub = mock_stub
+        client._version_pb2 = MagicMock()
+        client._server_version = None
+
+        with pytest.warns(DeprecationWarning, match="get_server_version"):
+            v1 = client.server_version
+
+        assert v1.version == "0.3.1"
+        assert mock_stub.GetServerInfo.call_count == 1
+
+        with pytest.warns(DeprecationWarning, match="get_server_version"):
+            v2 = client.server_version
+
         assert v2 is v1
         assert mock_stub.GetServerInfo.call_count == 1
 


### PR DESCRIPTION
## Summary

- add `ConfigClient.get_server_version()` to match `AsyncConfigClient.get_server_version()`
- keep `ConfigClient.server_version` as a deprecated property that emits `DeprecationWarning`
- update compatibility checks, tests, docs, and the quickstart example to use the explicit method

## Related issues

Closes #52

## Test plan

- [x] `git diff --check`
- [x] `git diff --cached --check`
- Not run locally
- Not run locally
- Not run locally

## Checklist

- [ ] SDK regenerated if proto changed in `decree` - not applicable, no proto changes
- [ ] Breaking change flagged in title/description if applicable - not applicable, the existing property remains with a deprecation warning
- [ ] Changelog/release note added if applicable - not added; this is a small API consistency fix for an open issue