### PR TITLE
fix(client): replace server_version property with get_server_version() method

### DIFF
--- a/sdk/src/opendecree/client.py
+++ b/sdk/src/opendecree/client.py
@@ -11,6 +11,7 @@ All writes send string values — the server coerces to the schema-defined type.
 
 from __future__ import annotations
 
+import warnings
 from datetime import timedelta
 from typing import TYPE_CHECKING, overload
 
@@ -108,9 +109,8 @@ class ConfigClient:
     def __exit__(self, *exc: object) -> None:
         self.close()
 
-    @property
-    def server_version(self) -> ServerVersion:
-        """The server's version, fetched once and cached.
+    def get_server_version(self) -> ServerVersion:
+        """Fetch the server's version, cached after first call.
 
         Returns:
             ServerVersion with version and commit strings.
@@ -124,6 +124,16 @@ class ConfigClient:
             )
         return self._server_version
 
+    @property
+    def server_version(self) -> ServerVersion:
+        """Deprecated. Use :meth:`get_server_version` instead."""
+        warnings.warn(
+            "server_version property is deprecated; use get_server_version() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_server_version()
+
     def check_compatibility(self) -> None:
         """Check that the server version is compatible with this SDK.
 
@@ -135,7 +145,7 @@ class ConfigClient:
                 supported range.
             UnavailableError: If the server is unreachable.
         """
-        check_version_compatible(self.server_version.version)
+        check_version_compatible(self.get_server_version().version)
 
     # --- get() with @overload for type safety ---
 

--- a/sdk/tests/test_compat.py
+++ b/sdk/tests/test_compat.py
@@ -126,11 +126,11 @@ async def test_async_fetch_server_version():
     assert sv == ServerVersion(version="0.3.1", commit="abc123")
 
 
-# --- ConfigClient.server_version + check_compatibility ---
+# --- ConfigClient.get_server_version + check_compatibility ---
 
 
-def test_client_server_version_cached():
-    """server_version property fetches once, returns cached."""
+def test_client_get_server_version_cached():
+    """get_server_version() fetches once, returns cached."""
     with patch("opendecree.client.create_channel"):
         from opendecree import ConfigClient
 
@@ -147,14 +147,30 @@ def test_client_server_version_cached():
         client._server_version = None
 
         # First call fetches
-        v1 = client.server_version
+        v1 = client.get_server_version()
         assert v1.version == "0.3.1"
         assert mock_stub.GetServerInfo.call_count == 1
 
         # Second call returns cached
-        v2 = client.server_version
+        v2 = client.get_server_version()
         assert v2 is v1
         assert mock_stub.GetServerInfo.call_count == 1
+
+
+def test_client_server_version_property_deprecated():
+    """server_version property emits DeprecationWarning."""
+    with patch("opendecree.client.create_channel"):
+        from opendecree import ConfigClient
+
+        client = ConfigClient.__new__(ConfigClient)
+        client._timeout = 5.0
+        client._server_version = ServerVersion(version="0.3.1", commit="abc")
+        client._version_stub = MagicMock()
+        client._version_pb2 = MagicMock()
+
+        with pytest.warns(DeprecationWarning, match="get_server_version"):
+            sv = client.server_version
+        assert sv.version == "0.3.1"
 
 
 def test_client_check_compatibility_passes():


### PR DESCRIPTION
## Summary

- Properties should not hide I/O cost: `server_version` on the sync client triggered a gRPC call on access, while the async client already used the explicit method form `get_server_version()`.
- This aligns the sync API with the async API and makes the network round-trip visible at the call site.
- The old property is kept for one release with a `DeprecationWarning` pointing callers to the new method.

## Test plan

- [x] Renamed cached-fetch test to `test_client_get_server_version_cached` — covers call-once-then-cache behavior via `get_server_version()`
- [x] Added `test_client_server_version_property_deprecated` — asserts `DeprecationWarning` is emitted with the correct message when accessing the property
- [x] `check_compatibility()` calls `get_server_version()` directly — existing pass/fail tests cover this
- [x] Full suite: `204 passed`, `client.py` at 100% coverage

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)