### PR TITLE
docs: backfill CHANGELOG entries for 0.2.0 and 0.3.0a1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.3.0a1] - 2026-04-27
+
+### Added
+
+- `TimeoutError` (DEADLINE\_EXCEEDED), `ResourceExhaustedError`, `CancelledError`, and
+  `UnimplementedError` exception types extending the existing error hierarchy
+- `DecreeError` captures `trailing_metadata` from gRPC errors, preserving `google.rpc.RetryInfo`
+  and `ErrorInfo` trailers
+- `description`, `value_description`, and `expected_checksum` keyword arguments on `set()` and
+  `set_many()` for all sync and async client types
+- `datetime`, `dict`, `list`, and URL type coercion in value conversion (`convert.py`)
+- Dependabot configuration for automated dependency management (Python + GitHub Actions)
+- Community health: YAML bug report template and first-interaction welcome bot
+- Social preview image and PyPI downloads / repostatus badges in README
+- Codecov coverage upload and per-PR coverage reporting
+
+### Changed
+
+- Proto stubs regenerated for decree v0.8.0-alpha.1 and v0.10.0-alpha.1
+- Repository migrated from personal GitHub to the [opendecree](https://github.com/opendecree) org
+- `server_version` property replaced by `get_server_version()` method on all client classes
+  (property was not async-safe)
+- CI upgraded: GitHub Actions checkout v6, setup-python v6; CodeQL migrated to advanced setup
+
+### Fixed
+
+- Auth metadata now forwarded to `GetConfig` and `Subscribe` in `AsyncConfigWatcher`
+- Insecure Bearer tokens on TLS channels now log a warning; composite channel credentials used
+- Sync stream closing without an error now triggers exponential backoff before reconnect
+- `ConfigWatcher.stop()` cancels the gRPC stream to prevent thread leaks on shutdown
+- `py.typed` marker and `.pyi` stubs now included in the published wheel
+- Write operations (`set`, `set_many`, `delete`) no longer retried on `DEADLINE_EXCEEDED`
+- Generated proto imports use absolute package paths instead of `sys.path` injection
+- `spec_version` field name corrected in example seed (was `syntax`)
+
+## [0.2.0] - 2026-04-14
+
+### Added
+
+- End-to-end examples with seed data, proto generation, and multi-tenant usage
+- Multi-tenant usage documentation
+- Alpha status disclaimer in README and package classifiers
+
 ## [0.1.0] - 2026-04-12
 
 ### Added
@@ -19,4 +62,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `on_change` callbacks and `changes()` iterators on watched fields
 - Auto-reconnect with backoff on subscription stream failures
 
+[0.3.0a1]: https://github.com/opendecree/decree-python/releases/tag/v0.3.0a1
+[0.2.0]: https://github.com/opendecree/decree-python/releases/tag/v0.2.0
 [0.1.0]: https://github.com/opendecree/decree-python/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary

- The CHANGELOG had only the initial 0.1.0 entry while the published version was already 0.3.0a1, leaving users with no release history.
- Backfills 0.2.0 (examples, multi-tenant docs, alpha disclaimer) and 0.3.0a1 (org migration, proto stub updates, typed exceptions, watcher/auth/retry fixes, convert types, packaging fixes, and CI improvements).
- Adds Keep a Changelog reference link footers for all three versions.

## Test plan

- [ ] Rendered markdown looks correct on GitHub (headers, inline code, links)
- [ ] Reference links at the bottom resolve to the correct GitHub release tags
- [ ] 0.3.0a1 entries match the merged PRs in the git log (`git log v0.2.0..HEAD --oneline`)

Closes #55