### PR TITLE
fix(deps): add pdoc to dev optional dependencies

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "mypy-protobuf>=5.1.0",
     "ruff>=0.15.13",
     "grpcio-tools>=1.80.0",
+    "pdoc>=15.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

- `pdoc` was called by `make docs` but not declared in `[project.optional-dependencies].dev`, causing contributors with a clean environment to get a command-not-found error.

## Test plan

- [x] Added `pdoc>=15.0.0` to dev optional dependencies in `sdk/pyproject.toml`
- [x] Ran `make docs` — generated API docs in `sdk/docs/api/` successfully

Closes #56