### PR TITLE
Rename get() type param to value_type to avoid shadowing builtin

### DIFF
--- a/sdk/src/opendecree/async_client.py
+++ b/sdk/src/opendecree/async_client.py
@@ -161,23 +161,25 @@ class AsyncConfigClient:
     async def get(self, tenant_id: str, field_path: str) -> str: ...
 
     @overload
-    async def get(self, tenant_id: str, field_path: str, type: type[bool]) -> bool: ...
+    async def get(self, tenant_id: str, field_path: str, value_type: type[bool]) -> bool: ...
 
     @overload
-    async def get(self, tenant_id: str, field_path: str, type: type[int]) -> int: ...
+    async def get(self, tenant_id: str, field_path: str, value_type: type[int]) -> int: ...
 
     @overload
-    async def get(self, tenant_id: str, field_path: str, type: type[float]) -> float: ...
+    async def get(self, tenant_id: str, field_path: str, value_type: type[float]) -> float: ...
 
     @overload
-    async def get(self, tenant_id: str, field_path: str, type: type[timedelta]) -> timedelta: ...
+    async def get(
+        self, tenant_id: str, field_path: str, value_type: type[timedelta]
+    ) -> timedelta: ...
 
     @overload
     async def get(
         self,
         tenant_id: str,
         field_path: str,
-        type: type[str],
+        value_type: type[str],
         *,
         nullable: bool,
     ) -> str | None: ...
@@ -186,7 +188,7 @@ class AsyncConfigClient:
         self,
         tenant_id: str,
         field_path: str,
-        type: type | None = None,
+        value_type: type | None = None,
         *,
         nullable: bool = False,
     ) -> object:
@@ -198,7 +200,7 @@ class AsyncConfigClient:
         Args:
             tenant_id: Tenant UUID.
             field_path: Dot-separated field path (e.g., "payments.fee").
-            type: Target type (str, int, float, bool, timedelta). Defaults to str.
+            value_type: Target type (str, int, float, bool, timedelta). Defaults to str.
             nullable: If True, return None for null/unset values instead of raising.
 
         Returns:
@@ -208,7 +210,7 @@ class AsyncConfigClient:
             NotFoundError: If the field has no value (and nullable is False).
             TypeMismatchError: If the value cannot be converted to the requested type.
         """
-        target_type = type or str
+        target_type = value_type or str
 
         async def _call() -> object:
             resp = await self._stub.GetField(

--- a/sdk/src/opendecree/client.py
+++ b/sdk/src/opendecree/client.py
@@ -176,23 +176,23 @@ class ConfigClient:
     def get(self, tenant_id: str, field_path: str) -> str: ...
 
     @overload
-    def get(self, tenant_id: str, field_path: str, type: type[bool]) -> bool: ...
+    def get(self, tenant_id: str, field_path: str, value_type: type[bool]) -> bool: ...
 
     @overload
-    def get(self, tenant_id: str, field_path: str, type: type[int]) -> int: ...
+    def get(self, tenant_id: str, field_path: str, value_type: type[int]) -> int: ...
 
     @overload
-    def get(self, tenant_id: str, field_path: str, type: type[float]) -> float: ...
+    def get(self, tenant_id: str, field_path: str, value_type: type[float]) -> float: ...
 
     @overload
-    def get(self, tenant_id: str, field_path: str, type: type[timedelta]) -> timedelta: ...
+    def get(self, tenant_id: str, field_path: str, value_type: type[timedelta]) -> timedelta: ...
 
     @overload
     def get(
         self,
         tenant_id: str,
         field_path: str,
-        type: type[str],
+        value_type: type[str],
         *,
         nullable: bool,
     ) -> str | None: ...
@@ -201,7 +201,7 @@ class ConfigClient:
         self,
         tenant_id: str,
         field_path: str,
-        type: type | None = None,
+        value_type: type | None = None,
         *,
         nullable: bool = False,
     ) -> object:
@@ -213,7 +213,7 @@ class ConfigClient:
         Args:
             tenant_id: Tenant UUID.
             field_path: Dot-separated field path (e.g., "payments.fee").
-            type: Target type (str, int, float, bool, timedelta). Defaults to str.
+            value_type: Target type (str, int, float, bool, timedelta). Defaults to str.
             nullable: If True, return None for null/unset values instead of raising.
 
         Returns:
@@ -223,7 +223,7 @@ class ConfigClient:
             NotFoundError: If the field has no value (and nullable is False).
             TypeMismatchError: If the value cannot be converted to the requested type.
         """
-        target_type = type or str
+        target_type = value_type or str
 
         def _call() -> object:
             resp = self._stub.GetField(


### PR DESCRIPTION
## Summary

- The `type` parameter in `get()` (sync and async) shadowed Python's built-in `type`, making static analysis tools emit warnings and surprising users reading the signature.
- Renamed to `value_type` across all overloads and the implementation in both `client.py` and `async_client.py`.

## Test plan

- [x] All 222 tests pass (`make test`)
- [x] Lint clean (`make lint`) — also caught and fixed a line-length regression in the async overload

Closes #57