### PR TITLE
fix(_retry): add RESOURCE_EXHAUSTED to default retryable codes

### DIFF
--- a/sdk/src/opendecree/_retry.py
+++ b/sdk/src/opendecree/_retry.py
@@ -42,6 +42,7 @@ class RetryConfig:
         default=(
             grpc.StatusCode.UNAVAILABLE,
             grpc.StatusCode.DEADLINE_EXCEEDED,
+            grpc.StatusCode.RESOURCE_EXHAUSTED,
         )
     )
     total_timeout: float | None = None

--- a/sdk/tests/test_retry.py
+++ b/sdk/tests/test_retry.py
@@ -64,6 +64,18 @@ def test_retry_config_defaults():
     assert cfg.multiplier == 2.0
     assert grpc.StatusCode.UNAVAILABLE in cfg.retryable_codes
     assert grpc.StatusCode.DEADLINE_EXCEEDED in cfg.retryable_codes
+    assert grpc.StatusCode.RESOURCE_EXHAUSTED in cfg.retryable_codes
+
+
+def test_retry_on_resource_exhausted():
+    err = FakeRpcError(grpc.StatusCode.RESOURCE_EXHAUSTED)
+    fn = MagicMock(side_effect=[err, "ok"])
+
+    with patch("opendecree._retry.time.sleep"):
+        result = with_retry(RetryConfig(max_attempts=3), fn)
+
+    assert result == "ok"
+    assert fn.call_count == 2
 
 
 def test_write_safe_config_strips_deadline_exceeded():


### PR DESCRIPTION
## Summary
- RESOURCE_EXHAUSTED means the server rejected the request (rate limit), not that it was applied — safe to retry.
- Aligns the default retryable codes with common gRPC retry guidance, which includes rate-limited responses.

## Test plan
- Updated `test_retry_config_defaults` to assert RESOURCE_EXHAUSTED is in the default set.
- Added `test_retry_on_resource_exhausted` to verify sync retry succeeds on that code.
- Full test suite passes (`228 passed, 97% coverage`).

Closes #59