### PR TITLE
docs: pin examples to opendecree>=0.3.0a1 and document --pre install

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -18,8 +18,10 @@ The tenant ID is written to `.tenant-id` — examples read it automatically.
 
 ## Prerequisites
 
+OpenDecree is currently in alpha. Install with the `--pre` flag so pip's resolver includes pre-release versions:
+
 ```bash
-pip install opendecree
+pip install --pre opendecree
 ```
 
 For the FastAPI example, also install:

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,1 +1,1 @@
-opendecree>=0.1.0
+opendecree>=0.3.0a1


### PR DESCRIPTION
## Summary

- Alpha releases are excluded by pip's default resolver; pinning to `>=0.3.0a1` ensures the current release is installable.
- The `--pre` flag is required until the SDK reaches a stable release, and was previously undocumented in the examples README.

## Test plan

- [ ] Verify `pip install --pre opendecree>=0.3.0a1` resolves without `--pre` flag warning
- [ ] Confirm README prerequisites section clearly describes the `--pre` requirement

Closes #66