### PR TITLE
fix(watcher): sanitize tenant_id in asyncio task and thread names

### DIFF
--- a/sdk/src/opendecree/async_watcher.py
+++ b/sdk/src/opendecree/async_watcher.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+import re
 from collections.abc import AsyncIterator, Callable
 from typing import Any, TypeVar
 
@@ -37,6 +38,8 @@ from opendecree._watcher_base import (
 from opendecree.types import Change
 
 logger = logging.getLogger("opendecree.async_watcher")
+
+_CONTROL_CHARS_RE = re.compile(r"[^\x20-\x7E]")
 
 T = TypeVar("T")
 
@@ -152,9 +155,8 @@ class AsyncConfigWatcher:
 
         await self._load_snapshot()
         self._stopped = False
-        self._task = asyncio.create_task(
-            self._subscribe_loop(), name=f"decree-watcher-{self._tenant_id}"
-        )
+        safe_id = _CONTROL_CHARS_RE.sub("", self._tenant_id)
+        self._task = asyncio.create_task(self._subscribe_loop(), name=f"decree-watcher-{safe_id}")
 
     async def stop(self) -> None:
         """Stop watching and cancel the background task."""

--- a/sdk/src/opendecree/watcher.py
+++ b/sdk/src/opendecree/watcher.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import logging
 import queue
 import random
+import re
 import threading
 import time
 from collections.abc import Callable, Iterator
@@ -36,6 +37,8 @@ from opendecree._watcher_base import (
 from opendecree.types import Change
 
 logger = logging.getLogger("opendecree.watcher")
+
+_CONTROL_CHARS_RE = re.compile(r"[^\x20-\x7E]")
 
 T = TypeVar("T")
 
@@ -156,8 +159,9 @@ class ConfigWatcher:
 
         self._load_snapshot()
         self._stop_event.clear()
+        safe_id = _CONTROL_CHARS_RE.sub("", self._tenant_id)
         self._thread = threading.Thread(
-            target=self._subscribe_loop, daemon=True, name=f"decree-watcher-{self._tenant_id}"
+            target=self._subscribe_loop, daemon=True, name=f"decree-watcher-{safe_id}"
         )
         self._thread.start()
 

--- a/sdk/tests/test_async_watcher.py
+++ b/sdk/tests/test_async_watcher.py
@@ -341,3 +341,25 @@ class TestAsyncConfigWatcher:
         stub.Subscribe.assert_called_once()
         _, sub_kwargs = stub.Subscribe.call_args
         assert sub_kwargs.get("metadata") == auth_meta
+
+    @pytest.mark.asyncio
+    async def test_task_name_sanitizes_control_chars(self):
+        stub = MagicMock()
+        pb2 = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.config.values = []
+        stub.GetConfig = AsyncMock(return_value=mock_resp)
+
+        async def empty_stream():
+            return
+            yield
+
+        stub.Subscribe.return_value = empty_stream()
+
+        w = AsyncConfigWatcher(stub, pb2, "tenant\x00evil\x1f", timeout=5.0)
+        await w.start()
+        assert w._task is not None
+        assert "\x00" not in w._task.get_name()
+        assert "\x1f" not in w._task.get_name()
+        assert "tenantevil" in w._task.get_name()
+        await w.stop()

--- a/sdk/tests/test_watcher.py
+++ b/sdk/tests/test_watcher.py
@@ -403,3 +403,19 @@ class TestConfigWatcher:
         # Thread must have joined within the timeout.
         assert not thread_ref.is_alive()
         assert w._thread is None
+
+    def test_thread_name_sanitizes_control_chars(self):
+        stub = MagicMock()
+        pb2 = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.config.values = []
+        stub.GetConfig.return_value = mock_resp
+        stub.Subscribe.return_value = iter([])
+
+        w = ConfigWatcher(stub, pb2, "tenant\x00evil\x1f", timeout=5.0)
+        w.start()
+        assert w._thread is not None
+        assert "\x00" not in w._thread.name
+        assert "\x1f" not in w._thread.name
+        assert "tenantevil" in w._thread.name
+        w.stop()


### PR DESCRIPTION
## Summary

- Task and thread names included `tenant_id` verbatim, allowing user-controlled control characters to appear in `asyncio` task names and `threading.Thread` names.
- Adds a module-level compiled regex that strips everything outside the printable ASCII range (0x20–0x7E) before embedding the ID in the name.

## Test plan

- [x] `test_thread_name_sanitizes_control_chars` — verifies sync watcher strips `\x00` and `\x1f` from thread name
- [x] `test_task_name_sanitizes_control_chars` — verifies async watcher strips same chars from asyncio task name
- [x] 254 tests pass, 97.55% coverage (above 95% threshold)

Closes #70