### PR TITLE
Remove ConfigValue from public API

### DIFF
--- a/sdk/src/opendecree/__init__.py
+++ b/sdk/src/opendecree/__init__.py
@@ -29,7 +29,7 @@ from opendecree.errors import (
     UnavailableError,
     UnimplementedError,
 )
-from opendecree.types import Change, ConfigValue, FieldUpdate, ServerVersion
+from opendecree.types import Change, FieldUpdate, ServerVersion
 from opendecree.watcher import ConfigWatcher, WatchedField
 
 __all__ = [
@@ -44,7 +44,6 @@ __all__ = [
     "Change",
     "ChecksumMismatchError",
     "ConfigClient",
-    "ConfigValue",
     "ConfigWatcher",
     "DecreeError",
     "FieldUpdate",

--- a/sdk/src/opendecree/types.py
+++ b/sdk/src/opendecree/types.py
@@ -9,23 +9,6 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True, slots=True)
-class ConfigValue:
-    """A single configuration value.
-
-    Attributes:
-        field_path: Dot-separated field path (e.g., ``"payments.fee"``).
-        value: The raw string value.
-        checksum: xxHash checksum of the value.
-        description: Optional description set when the value was written.
-    """
-
-    field_path: str
-    value: str
-    checksum: str
-    description: str = ""
-
-
-@dataclass(frozen=True, slots=True)
 class Change:
     """A configuration change event from a subscription.
 

--- a/sdk/tests/test_types.py
+++ b/sdk/tests/test_types.py
@@ -1,14 +1,6 @@
 """Tests for public data types."""
 
-from opendecree.types import Change, ConfigValue, ServerVersion
-
-
-def test_config_value_frozen():
-    cv = ConfigValue(field_path="a.b", value="1", checksum="abc")
-    assert cv.field_path == "a.b"
-    assert cv.value == "1"
-    assert cv.checksum == "abc"
-    assert cv.description == ""
+from opendecree.types import Change, ServerVersion
 
 
 def test_change():


### PR DESCRIPTION
## Summary

- `ConfigValue` was exported in `__all__` but no SDK method returned or accepted it, making it a confusing dead export.
- Removed the class from `types.py`, its import and `__all__` entry in `__init__.py`, and the corresponding test.

## Test plan

- [x] `make test` passes — 253 tests, 97.53% coverage

Closes #73