### PR TITLE
Add Codespaces devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+ARG UV_VERSION=0.11.16
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
+
+FROM mcr.microsoft.com/devcontainers/python:3.12
+
+COPY --from=uv /uv /uvx /usr/local/bin/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "OpenDecree Python SDK",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "postCreateCommand": "uv venv --python 3.12 .venv && uv pip install --python .venv/bin/python -e \"sdk[dev]\"",
+  "remoteEnv": {
+    "VIRTUAL_ENV": "${workspaceFolder}/.venv",
+    "PATH": "${workspaceFolder}/.venv/bin:${containerEnv:PATH}"
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+        "python.testing.pytestArgs": [
+          "sdk/tests"
+        ],
+        "python.testing.pytestEnabled": true,
+        "ruff.nativeServer": "on"
+      },
+      "extensions": [
+        "ms-python.python",
+        "ms-python.mypy-type-checker",
+        "charliermarsh.ruff"
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/github/license/opendecree/decree-python)](LICENSE)
 [![Project Status: WIP](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![codecov](https://codecov.io/gh/opendecree/decree-python/graph/badge.svg)](https://codecov.io/gh/opendecree/decree-python)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/opendecree/decree-python)
 
 Python SDK for [OpenDecree](https://github.com/opendecree/decree) — schema-driven configuration management.
 


### PR DESCRIPTION
## Summary

- Add a Codespaces/devcontainer setup for Python 3.12.
- Install `uv` from the official `ghcr.io/astral-sh/uv` image and use it to create `.venv` with `sdk[dev]` dependencies after container creation.
- Add an "Open in GitHub Codespaces" badge to the README.

## Related issues

Closes #9

## Test plan

- [x] `devcontainer.json` parses as JSON
- [x] `git diff --check HEAD~1..HEAD`
- [ ] `make lint` passes
- [ ] `make typecheck` passes
- [ ] `make test` passes

Not run locally: `make lint`, `make typecheck`, `make test`.

## Checklist

- [x] SDK regenerated if proto changed in `decree` (not applicable)
- [x] Breaking change flagged in title/description if applicable (not applicable)
- [x] Changelog/release note added if applicable (not applicable)
