### PR TITLE
docs: document fork-safety limitation for gRPC channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ with ConfigClient("localhost:9090", subject="myapp") as client:
             print(f"Fee changed: {old} -> {new}")
 ```
 
+> **Fork safety:** gRPC channels are not fork-safe. Create `ConfigClient` (and start any watcher)
+> *after* forking — not before. See [Fork safety](sdk/docs/watching.md#fork-safety) for details.
+
 ## Async
 
 ```python

--- a/sdk/docs/watching.md
+++ b/sdk/docs/watching.md
@@ -120,6 +120,41 @@ with ConfigClient("localhost:9090", subject="myapp") as client:
         print(fee_a.value, fee_b.value)
 ```
 
+## Fork safety
+
+gRPC channels are **not fork-safe**. Do not create a `ConfigClient` (or `AsyncConfigClient`) before
+calling `os.fork()` — this includes implicit forks from `multiprocessing.Pool`, Gunicorn workers,
+and similar process-spawning frameworks.
+
+After a fork, the child inherits the open gRPC channel. The channel's internal threads and file
+descriptors are in an undefined state, which can cause hangs, crashes, or silent data corruption.
+
+**Fix: create the client inside the worker, not before forking.**
+
+```python
+from multiprocessing import Pool
+from opendecree import ConfigClient
+
+def worker(tenant_id: str) -> str:
+    # Safe — client created after fork
+    with ConfigClient("localhost:9090", subject="myapp") as client:
+        return client.get(tenant_id, "payments.fee")
+
+with Pool(4) as pool:
+    results = pool.map(worker, ["tenant-a", "tenant-b"])
+```
+
+If you must use `multiprocessing`, prefer the `spawn` start method (default on macOS and Windows)
+over `fork` — it avoids inheriting the parent's file descriptors entirely:
+
+```python
+import multiprocessing
+multiprocessing.set_start_method("spawn")
+```
+
+The same restriction applies to `ConfigWatcher`: the background thread does not survive a fork.
+Stop the watcher before forking, or start it inside the child process.
+
 ## Next steps
 
 - [Async Usage](async.md) — async watcher with `async for` iteration


### PR DESCRIPTION
## Summary

- gRPC channels are not fork-safe, but this was undocumented — users relying on multiprocessing or Gunicorn workers would hit silent hangs or crashes with no guidance on why or how to fix it.
- Adds a dedicated "Fork safety" section to `watching.md` explaining the root cause, showing the correct pattern (create the client inside the worker), and recommending the `spawn` start method.
- Adds a brief callout to `README.md` pointing to that section so the warning is visible without digging into the docs.

## Test plan

- [ ] Reviewed rendered Markdown for readability and correct anchor links
- [ ] Confirmed `#fork-safety` anchor in `watching.md` matches the README link target

Closes #69