### PR TITLE
test: raise unit test coverage to 100% across all SDK modules

### DIFF
--- a/sdk/tests/test_async_client.py
+++ b/sdk/tests/test_async_client.py
@@ -317,3 +317,68 @@ class TestAsyncConfigClientUnit:
             mock_ch.return_value = MagicMock()
             AsyncConfigClient("localhost:9090", interceptors=[a, b])
         assert mock_ch.call_args.kwargs["interceptors"] == [a, b]
+
+    def test_insecure_token_emits_warning(self):
+        import warnings
+
+        with patch("opendecree.async_client.create_aio_channel") as mock_ch:
+            mock_ch.return_value = MagicMock()
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                AsyncConfigClient("localhost:9090", insecure=True, token="tok")
+        assert len(w) == 1
+        assert issubclass(w[0].category, UserWarning)
+        assert "cleartext" in str(w[0].message)
+
+    @pytest.mark.asyncio
+    async def test_get_server_version(self):
+        client = self._make_client()
+        from opendecree.types import ServerVersion
+
+        sv = ServerVersion(version="0.2.0", commit="abc123")
+        with patch(
+            "opendecree.async_client.async_fetch_server_version",
+            new_callable=AsyncMock,
+            return_value=sv,
+        ) as mock_fetch:
+            result = await client.get_server_version()
+        assert result == sv
+        mock_fetch.assert_called_once()
+        # Second call uses cache — fetch not called again
+        with patch(
+            "opendecree.async_client.async_fetch_server_version",
+            new_callable=AsyncMock,
+        ) as mock_fetch2:
+            result2 = await client.get_server_version()
+        assert result2 == sv
+        mock_fetch2.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_check_version_true_triggers_compat_check_on_first_call(self):
+        with patch("opendecree.async_client.create_aio_channel") as mock_ch:
+            mock_ch.return_value = MagicMock()
+            client = AsyncConfigClient("localhost:9090", check_version=True)
+        client._stub = MagicMock()
+
+        from opendecree._generated.centralconfig.v1 import types_pb2
+
+        mock_resp = MagicMock()
+        mock_resp.value.HasField.return_value = True
+        mock_resp.value.value = types_pb2.TypedValue(string_value="hello")
+        client._stub.GetField = AsyncMock(return_value=mock_resp)
+
+        from opendecree.types import ServerVersion
+
+        sv = ServerVersion(version="0.2.0", commit="abc")
+        with patch(
+            "opendecree.async_client.async_fetch_server_version",
+            new_callable=AsyncMock,
+            return_value=sv,
+        ):
+            with patch("opendecree.async_client.check_version_compatible") as mock_check:
+                result = await client.get("t1", "some.field")
+
+        mock_check.assert_called_once_with("0.2.0")
+        assert result == "hello"
+        # version_checked flag prevents second check
+        assert client._version_checked is True

--- a/sdk/tests/test_async_watcher.py
+++ b/sdk/tests/test_async_watcher.py
@@ -196,6 +196,30 @@ class TestAsyncWatchedField:
         assert _DEFAULT_MAX_QUEUE_SIZE == 1024
 
     @pytest.mark.asyncio
+    async def test_changes_spurious_wake_skipped(self):
+        f = AsyncWatchedField("x", str, "")
+        f._load_initial("a")
+
+        # Set event without putting anything in the queue → spurious wake
+        f._queue_event.set()
+
+        async def _collect_first():
+            async for c in f.changes():
+                return c
+
+        task = asyncio.create_task(_collect_first())
+        # Yield twice so the task can process the spurious wake (clears event, loops back)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        # Now deliver a real change + stop
+        change = Change(field_path="x", old_value="a", new_value="b", version=1)
+        f._update("b", change)
+
+        result = await asyncio.wait_for(task, timeout=2.0)
+        assert result.new_value == "b"
+
+    @pytest.mark.asyncio
     async def test_changes_iterator_after_overflow(self):
         f = AsyncWatchedField("x", str, "", max_queue_size=2)
         for i in range(4):
@@ -409,6 +433,81 @@ class TestAsyncConfigWatcher:
         stub.Subscribe.assert_called_once()
         _, sub_kwargs = stub.Subscribe.call_args
         assert sub_kwargs.get("metadata") == auth_meta
+
+    @pytest.mark.asyncio
+    async def test_processes_stream_response(self):
+        from opendecree._generated.centralconfig.v1 import types_pb2
+
+        w = self._make_watcher()
+        fee = w.field("fee", float, default=0.0)
+
+        response = MagicMock()
+        response.change.field_path = "fee"
+        response.change.HasField.side_effect = lambda name: name in ("old_value", "new_value")
+        response.change.old_value = types_pb2.TypedValue(string_value="0.0")
+        response.change.new_value = types_pb2.TypedValue(string_value="1.5")
+        response.change.version = 1
+        response.change.changed_by = ""
+
+        async def stream_with_one_response():
+            yield response
+            # Stream ends normally (server closed)
+
+        w._stub.Subscribe = MagicMock(return_value=stream_with_one_response())
+
+        await w.start()
+        await asyncio.sleep(0.2)
+        await w.stop()
+
+        assert fee.value == pytest.approx(1.5)
+
+    @pytest.mark.asyncio
+    async def test_stream_loop_returns_when_stopped_during_iteration(self):
+        from opendecree._generated.centralconfig.v1 import types_pb2
+
+        w = self._make_watcher()
+        w.field("fee", float, default=0.0)
+
+        response = MagicMock()
+        response.change.field_path = "fee"
+        response.change.HasField.side_effect = lambda name: name in ("old_value", "new_value")
+        response.change.old_value = types_pb2.TypedValue(string_value="0.0")
+        response.change.new_value = types_pb2.TypedValue(string_value="1.5")
+        response.change.version = 1
+        response.change.changed_by = ""
+
+        async def stream_already_stopped():
+            w._stopped = True  # mark stopped before the loop body runs
+            yield response
+
+        w._stub.Subscribe = MagicMock(return_value=stream_already_stopped())
+
+        await w.start()
+        await asyncio.sleep(0.2)
+
+        assert w._task is not None
+        assert w._task.done()
+        await w.stop()
+
+    @pytest.mark.asyncio
+    async def test_stream_aiorpc_error_while_stopped_exits_cleanly(self):
+        w = self._make_watcher()
+        w.field("fee", float, default=0.0)
+
+        async def error_after_stop():
+            w._stopped = True  # mark stopped before raising
+            raise FakeRpcError(grpc.StatusCode.UNAVAILABLE, "gone")
+            yield  # makes it an async generator
+
+        w._stub.Subscribe = MagicMock(return_value=error_after_stop())
+
+        await w.start()
+        await asyncio.sleep(0.2)
+
+        # Task should have exited cleanly (stopped=True path)
+        assert w._task is not None
+        assert w._task.done()
+        await w.stop()
 
     @pytest.mark.asyncio
     async def test_task_name_sanitizes_control_chars(self):

--- a/sdk/tests/test_channel.py
+++ b/sdk/tests/test_channel.py
@@ -181,3 +181,25 @@ class TestCreateAioChannel:
             opts = dict(kwargs["options"])
             assert opts["grpc.keepalive_time_ms"] == 60000
             assert opts["grpc.keepalive_timeout_ms"] == 5000
+
+
+def test_token_call_credentials_callback_injects_bearer():
+    from opendecree._channel import _token_call_credentials
+
+    captured = []
+
+    def fake_metadata_call_creds(fn):
+        captured.append(fn)
+        return MagicMock(spec=grpc.CallCredentials)
+
+    with patch(
+        "opendecree._channel.grpc.metadata_call_credentials",
+        side_effect=fake_metadata_call_creds,
+    ):
+        _token_call_credentials("secret-tok")
+
+    # Invoke the captured inner callback directly
+    received = []
+    captured[0](None, lambda meta, err: received.append((meta, err)))
+    assert received[0][0] == [("authorization", "Bearer secret-tok")]
+    assert received[0][1] is None

--- a/sdk/tests/test_convert.py
+++ b/sdk/tests/test_convert.py
@@ -276,3 +276,26 @@ def test_typed_value_to_string_time():
     tv = types_pb2.TypedValue(time_value=t)
     result = typed_value_to_string(tv)
     assert "2023" in result  # RFC 3339 format
+
+
+def test_typed_value_to_string_unknown_kind():
+    """The case _ fallback returns str(val) for unrecognised kind strings."""
+    from unittest.mock import patch
+
+    from opendecree._convert import typed_value_to_string
+    from opendecree._generated.centralconfig.v1 import types_pb2
+
+    class FakeTV:
+        def WhichOneof(self, name):  # noqa: N802
+            return "exotic_kind"
+
+        def __getattr__(self, name):
+            return "exotic_value"
+
+    fake_instance = FakeTV()
+
+    # Patch the TypedValue class inside the generated module so isinstance passes.
+    with patch.object(types_pb2, "TypedValue", FakeTV):
+        result = typed_value_to_string(fake_instance)
+
+    assert result == "exotic_value"

--- a/sdk/tests/test_retry.py
+++ b/sdk/tests/test_retry.py
@@ -224,3 +224,55 @@ async def test_async_deadline_exhausted_raises_immediately():
                 await async_with_retry(RetryConfig(max_attempts=3, total_timeout=0.1), fn)
 
     assert slept == []
+
+
+@pytest.mark.asyncio
+async def test_async_deadline_already_passed_before_second_attempt():
+    """Async loop-top deadline check stops further attempts once budget is exhausted."""
+    err = FakeRpcError(grpc.StatusCode.UNAVAILABLE)
+    call_count = 0
+
+    async def fn() -> str:
+        nonlocal call_count
+        call_count += 1
+        raise err
+
+    slept: list[float] = []
+
+    async def fake_sleep(s: float) -> None:
+        slept.append(s)
+
+    with patch("opendecree._retry.asyncio.sleep", side_effect=fake_sleep):
+        # monotonic: [deadline_start, loop-top-0 ok, remaining ok, loop-top-1 expired]
+        with patch("opendecree._retry.time.monotonic", side_effect=[0.0, 0.0, 0.05, 0.2]):
+            with pytest.raises(grpc.aio.AioRpcError):
+                await async_with_retry(RetryConfig(max_attempts=3, total_timeout=0.1), fn)
+
+    assert call_count == 1  # second attempt blocked by loop-top break
+
+
+@pytest.mark.asyncio
+async def test_async_deadline_clips_sleep():
+    """Async sleep is clipped to remaining budget so total wall time stays bounded."""
+    err = FakeRpcError(grpc.StatusCode.UNAVAILABLE)
+    call_count = 0
+
+    async def fn() -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise err
+        return "ok"
+
+    slept: list[float] = []
+
+    async def fake_sleep(s: float) -> None:
+        slept.append(s)
+
+    with patch("opendecree._retry.asyncio.sleep", side_effect=fake_sleep):
+        # monotonic: [deadline_start=0.0, loop-top-0=0.0, remaining-check=0.05, loop-top-1=0.05]
+        with patch("opendecree._retry.time.monotonic", side_effect=[0.0, 0.0, 0.05, 0.05]):
+            result = await async_with_retry(RetryConfig(max_attempts=3, total_timeout=0.1), fn)
+
+    assert result == "ok"
+    assert slept[0] <= 0.05 + 1e-9  # sleep clipped to remaining budget

--- a/sdk/tests/test_watcher.py
+++ b/sdk/tests/test_watcher.py
@@ -229,6 +229,38 @@ class TestWatchedField:
         assert f._max_queue_size == _DEFAULT_MAX_QUEUE_SIZE
         assert _DEFAULT_MAX_QUEUE_SIZE == 1024
 
+    def test_changes_blocks_until_change_arrives(self):
+        import threading
+
+        f = WatchedField("x", str, "")
+        f._load_initial("a")
+
+        results: list = []
+        done = threading.Event()
+
+        def consume():
+            for c in f.changes():
+                results.append(c)
+                break
+            done.set()
+
+        t = threading.Thread(target=consume, daemon=True)
+        t.start()
+
+        time.sleep(0.05)  # let thread enter the wait
+
+        from opendecree.types import Change
+
+        change = Change(field_path="x", old_value="a", new_value="b", version=1)
+        f._update("b", change)
+        f._stop()
+
+        done.wait(timeout=2.0)
+        t.join(timeout=2.0)
+
+        assert len(results) == 1
+        assert results[0].new_value == "b"
+
     def test_changes_iterator_after_overflow(self):
         from opendecree.types import Change
 
@@ -499,3 +531,106 @@ class TestConfigWatcher:
         assert "\x1f" not in w._thread.name
         assert "tenantevil" in w._thread.name
         w.stop()
+
+    def test_processes_stream_response(self):
+        from opendecree._generated.centralconfig.v1 import types_pb2
+
+        stub = MagicMock()
+        pb2 = MagicMock()
+        mock_config_resp = MagicMock()
+        mock_config_resp.config.values = []
+        stub.GetConfig.return_value = mock_config_resp
+
+        w = ConfigWatcher(stub, pb2, "t1", timeout=5.0)
+        fee = w.field("fee", float, default=0.0)
+
+        response = MagicMock()
+        response.change.field_path = "fee"
+        response.change.HasField.side_effect = lambda name: name in ("old_value", "new_value")
+        response.change.old_value = types_pb2.TypedValue(string_value="0.0")
+        response.change.new_value = types_pb2.TypedValue(string_value="1.5")
+        response.change.version = 1
+        response.change.changed_by = ""
+
+        stub.Subscribe.return_value = iter([response])
+
+        w.start()
+        time.sleep(0.2)
+        w.stop()
+
+        assert fee.value == pytest.approx(1.5)
+
+    def test_stream_loop_returns_when_stopped_during_iteration(self):
+        stub = MagicMock()
+        pb2 = MagicMock()
+        mock_config_resp = MagicMock()
+        mock_config_resp.config.values = []
+        stub.GetConfig.return_value = mock_config_resp
+
+        w = ConfigWatcher(stub, pb2, "t1", timeout=5.0)
+        w.field("fee", float, default=0.0)
+
+        class StopThenYieldStream:
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                w._stop_event.set()  # mark stopped before the loop body runs
+                response = MagicMock()
+                response.change.field_path = "fee"
+                response.change.HasField.side_effect = lambda name: (
+                    name
+                    in (
+                        "old_value",
+                        "new_value",
+                    )
+                )
+                from opendecree._generated.centralconfig.v1 import types_pb2
+
+                response.change.old_value = types_pb2.TypedValue(string_value="0.0")
+                response.change.new_value = types_pb2.TypedValue(string_value="1.5")
+                response.change.version = 1
+                response.change.changed_by = ""
+                return response
+
+            def cancel(self):
+                pass
+
+        stub.Subscribe.return_value = StopThenYieldStream()
+
+        w.start()
+        time.sleep(0.2)
+        w.stop()
+
+        # Thread exited via early return on line 248
+        assert w._thread is None
+
+    def test_stream_rpc_error_while_stopped_exits_cleanly(self):
+        stub = MagicMock()
+        pb2 = MagicMock()
+        mock_config_resp = MagicMock()
+        mock_config_resp.config.values = []
+        stub.GetConfig.return_value = mock_config_resp
+
+        w = ConfigWatcher(stub, pb2, "t1", timeout=5.0)
+        w.field("fee", float, default=0.0)
+
+        class ErrorStream:
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                w._stop_event.set()  # mark stopped before raising
+                raise FakeRpcError(grpc.StatusCode.UNAVAILABLE, "gone")
+
+            def cancel(self):
+                pass
+
+        stub.Subscribe.return_value = ErrorStream()
+
+        w.start()
+        time.sleep(0.2)
+        w.stop()
+
+        # Thread should have exited on line 265 return path
+        assert w._thread is None


### PR DESCRIPTION
## Summary

- Coverage had reached 97.52% from prior work but 23 statements across 6 modules remained uncovered; this PR closes every gap to reach 100%.
- The missing branches were edge-case paths: spurious async-event wakes, deadline-budget exhaustion in the async retry loop, stream-loop bodies that existing tests never exercised (all mocks used empty streams), early-return paths when a watcher is stopped mid-error, and the fallback branch in the TypedValue match.
- Hitting 100% removes the risk of undetected regressions in these exact paths, which include production-critical reconnect and error-handling logic.

## Test plan

- [x] _channel.py: capture and invoke the inner callback to confirm Bearer header injection
- [x] _convert.py: fake TypedValue with unknown kind to exercise the fallback case
- [x] _retry.py: two async deadline tests (loop-top break; sleep clipped to remaining budget)
- [x] async_client.py: UserWarning for insecure+token; get_server_version() caching; check_version=True lazy path
- [x] async_watcher.py: spurious-wake in changes(); stream loop body; AioRpcError while stopped
- [x] watcher.py: queue-cond wait when empty; stream loop body; RpcError while stop_event set
- [x] make lint passes (ruff check + format)
- [x] make test: 282 passed, 13 skipped, total coverage 100%

Closes #112