### PR TITLE
fix(watcher): graceful type-flip degradation + regression tests

### DIFF
--- a/sdk/src/opendecree/_watcher_base.py
+++ b/sdk/src/opendecree/_watcher_base.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from typing import Generic, TypeVar
 
 from opendecree._convert import convert_value
+from opendecree.errors import TypeMismatchError
 
 T = TypeVar("T")
 
@@ -57,8 +58,18 @@ class _WatchedFieldBase(Generic[T]):
         """Set _value/_is_set from a raw string. Returns (old, new). Caller must lock if needed."""
         old = self._value
         if raw_value is not None:
-            self._value = convert_value(raw_value, self._type)  # type: ignore[assignment]
-            self._is_set = True
+            try:
+                self._value = convert_value(raw_value, self._type)  # type: ignore[assignment]
+                self._is_set = True
+            except TypeMismatchError:
+                _logger.warning(
+                    "Type mismatch for field %r: cannot convert %r to %s, using default",
+                    self._path,
+                    raw_value,
+                    self._type.__name__,
+                )
+                self._value = self._default
+                self._is_set = False
         else:
             self._value = self._default
             self._is_set = False

--- a/sdk/tests/test_async_watcher.py
+++ b/sdk/tests/test_async_watcher.py
@@ -91,6 +91,26 @@ class TestAsyncWatchedField:
         f = AsyncWatchedField("payments.fee", float, 0.01)
         assert "payments.fee" in repr(f)
 
+    def test_load_initial_type_flip_falls_back_to_default(self):
+        f = AsyncWatchedField("payments.fee", float, 0.01)
+        f._load_initial("not-a-number")
+        assert f.value == pytest.approx(0.01)
+        assert not f._is_set
+
+    def test_update_type_flip_falls_back_to_default(self):
+        f = AsyncWatchedField("payments.fee", float, 0.01)
+        f._load_initial("0.025")
+        assert f.value == pytest.approx(0.025)
+
+        change = Change(
+            field_path="payments.fee", old_value="0.025", new_value="not-a-number", version=2
+        )
+        f._update("not-a-number", change)
+
+        # Falls back to default on type mismatch, does not crash.
+        assert f.value == pytest.approx(0.01)
+        assert not f._is_set
+
     def test_callback_exception_is_logged(self):
         f = AsyncWatchedField("x", int, 0)
         f._load_initial("1")
@@ -347,6 +367,36 @@ class TestAsyncConfigWatcher:
 
         w._process_change(change)
         assert fee.value == 2.0
+
+    def test_type_flip_mid_stream_uses_default_and_continues(self):
+        """Type-flip mid-stream falls back to default and keeps the stream alive."""
+        from opendecree._generated.centralconfig.v1 import types_pb2
+
+        w = self._make_watcher()
+        fee = w.field("fee", float, default=0.01)
+        fee._load_initial("0.025")
+
+        bad_change = MagicMock()
+        bad_change.field_path = "fee"
+        bad_change.HasField.side_effect = lambda name: name in ("old_value", "new_value")
+        bad_change.old_value = types_pb2.TypedValue(string_value="0.025")
+        bad_change.new_value = types_pb2.TypedValue(string_value="not-a-number")
+        bad_change.version = 2
+        bad_change.changed_by = ""
+
+        w._process_change(bad_change)
+        assert fee.value == pytest.approx(0.01)
+
+        good_change = MagicMock()
+        good_change.field_path = "fee"
+        good_change.HasField.side_effect = lambda name: name in ("old_value", "new_value")
+        good_change.old_value = types_pb2.TypedValue(string_value="not-a-number")
+        good_change.new_value = types_pb2.TypedValue(string_value="0.1")
+        good_change.version = 3
+        good_change.changed_by = ""
+
+        w._process_change(good_change)
+        assert fee.value == pytest.approx(0.1)
 
     def test_process_change_unknown_field_ignored(self):
         w = self._make_watcher()

--- a/sdk/tests/test_watcher.py
+++ b/sdk/tests/test_watcher.py
@@ -107,6 +107,28 @@ class TestWatchedField:
         assert "payments.fee" in repr(f)
         assert "0.01" in repr(f)
 
+    def test_load_initial_type_flip_falls_back_to_default(self):
+        f = WatchedField("payments.fee", float, 0.01)
+        f._load_initial("not-a-number")
+        assert f.value == pytest.approx(0.01)
+        assert not f._is_set
+
+    def test_update_type_flip_falls_back_to_default(self):
+        f = WatchedField("payments.fee", float, 0.01)
+        f._load_initial("0.025")
+        assert f.value == pytest.approx(0.025)
+
+        from opendecree.types import Change
+
+        change = Change(
+            field_path="payments.fee", old_value="0.025", new_value="not-a-number", version=2
+        )
+        f._update("not-a-number", change)
+
+        # Falls back to default on type mismatch, does not crash.
+        assert f.value == pytest.approx(0.01)
+        assert not f._is_set
+
     def test_callback_exception_is_logged(self):
         f = WatchedField("x", int, 0)
         f._load_initial("1")
@@ -372,6 +394,38 @@ class TestConfigWatcher:
 
         w._process_change(change)
         assert fee.value == 2.0
+
+    def test_type_flip_mid_stream_uses_default_and_continues(self):
+        """Type-flip mid-stream falls back to default and keeps the stream alive."""
+        from opendecree._generated.centralconfig.v1 import types_pb2
+
+        w = self._make_watcher()
+        fee = w.field("fee", float, default=0.01)
+        fee._load_initial("0.025")
+
+        # Type-flip: string value for a float field.
+        bad_change = MagicMock()
+        bad_change.field_path = "fee"
+        bad_change.HasField.side_effect = lambda name: name in ("old_value", "new_value")
+        bad_change.old_value = types_pb2.TypedValue(string_value="0.025")
+        bad_change.new_value = types_pb2.TypedValue(string_value="not-a-number")
+        bad_change.version = 2
+        bad_change.changed_by = ""
+
+        w._process_change(bad_change)
+        assert fee.value == pytest.approx(0.01)
+
+        # Subsequent valid change must still apply.
+        good_change = MagicMock()
+        good_change.field_path = "fee"
+        good_change.HasField.side_effect = lambda name: name in ("old_value", "new_value")
+        good_change.old_value = types_pb2.TypedValue(string_value="not-a-number")
+        good_change.new_value = types_pb2.TypedValue(string_value="0.1")
+        good_change.version = 3
+        good_change.changed_by = ""
+
+        w._process_change(good_change)
+        assert fee.value == pytest.approx(0.1)
 
     def test_process_change_unknown_field_ignored(self):
         w = self._make_watcher()


### PR DESCRIPTION
## Summary

- Fixes a crash bug: a server-side type change (e.g. field flips from `float` to `string`) would propagate `TypeMismatchError` uncaught through `_apply_raw` → `_update` → `_process_change`, killing the background subscribe thread/task silently.
- `_apply_raw` now catches `TypeMismatchError`, logs a warning, and resets to the field's registered default value — matching Go SDK behavior.
- Adds regression tests for sync (`WatchedField`, `ConfigWatcher`) and async (`AsyncWatchedField`, `AsyncConfigWatcher`) paths.

## Test plan

- [x] `test_load_initial_type_flip_falls_back_to_default` — snapshot with unconvertible value uses default.
- [x] `test_update_type_flip_falls_back_to_default` — stream update with unconvertible value uses default.
- [x] `test_type_flip_mid_stream_uses_default_and_continues` — bad update resets to default; subsequent valid update still applies.
- [x] All three tests pass for both sync (`test_watcher.py`) and async (`test_async_watcher.py`) variants.
- [x] Full test suite: 288 passed, 100% coverage maintained.

Refs opendecree/decree#563