### PR TITLE
feat: backfill GitHub releases and emit release on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -27,3 +27,6 @@ jobs:
         with:
           packages-dir: sdk/dist/
           print-hash: true
+      - run: gh release create "${{ github.ref_name }}" --generate-notes sdk/dist/*.whl sdk/dist/*.tar.gz
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/scripts/backfill-releases.sh
+++ b/scripts/backfill-releases.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYPI_PACKAGE="decree"
+VERSIONS=("0.1.0" "0.2.0")
+
+for version in "${VERSIONS[@]}"; do
+  tag="v${version}"
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' EXIT
+
+  echo "Fetching PyPI metadata for ${PYPI_PACKAGE} ${version}..."
+  metadata=$(curl -fsSL "https://pypi.org/pypi/${PYPI_PACKAGE}/${version}/json")
+
+  mapfile -t urls < <(echo "$metadata" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for f in data['urls']:
+    if f['packagetype'] in ('bdist_wheel', 'sdist'):
+        print(f['url'])
+")
+
+  for url in "${urls[@]}"; do
+    filename=$(basename "$url")
+    echo "Downloading ${filename}..."
+    curl -fsSL -o "${tmpdir}/${filename}" "$url"
+  done
+
+  echo "Creating GitHub release for ${tag}..."
+  gh release create "$tag" \
+    --repo opendecree/decree-python \
+    --generate-notes \
+    "${tmpdir}"/*.whl \
+    "${tmpdir}"/*.tar.gz
+
+  trap - EXIT
+  rm -rf "$tmpdir"
+done


### PR DESCRIPTION
## Summary

- Add `scripts/backfill-releases.sh`: a one-shot script that downloads wheel and sdist artifacts for the already-published PyPI versions (0.1.0, 0.2.0) from the PyPI JSON API and creates GitHub releases on the corresponding tags (`v0.1.0`, `v0.2.0`) with `--generate-notes` and attached artifacts.
- Update `.github/workflows/publish.yml`: upgrade the `publish` job's `contents` permission from `read` to `write` and add a `gh release create` step after the PyPI publish step, attaching the built artifacts from `sdk/dist/` so every future tag push produces a GitHub release automatically.

## Test plan

- [ ] Run `scripts/backfill-releases.sh` manually (requires `gh` auth as a repo admin) and confirm GitHub releases appear for `v0.1.0` and `v0.2.0` with `.whl` and `.tar.gz` attached.
- [ ] Push a new version tag to verify the updated workflow creates a GitHub release alongside the PyPI publish.
- [ ] Confirm CI passes on this PR.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)