### PR TITLE
feat: enable Sigstore wheel attestations on PyPI publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           packages-dir: sdk/dist/
           print-hash: true
+          attestations: true
       - run: gh release create "${{ github.ref_name }}" --generate-notes sdk/dist/*.whl sdk/dist/*.tar.gz
         env:
           GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ Runnable examples in the [`examples/`](examples/) directory:
 
 For detailed concepts (schemas, typed values, versioning, auth), see the [main OpenDecree docs](https://github.com/opendecree/decree).
 
+## Supply Chain Security
+
+Each release wheel is signed with [Sigstore](https://www.sigstore.dev/) via the GitHub Actions
+OIDC identity. Attestations are visible on the [PyPI project page](https://pypi.org/project/opendecree/).
+
+To verify a downloaded wheel locally:
+
+```bash
+pip download opendecree --no-deps
+gh attestation verify opendecree-*.whl --repo opendecree/decree-python
+```
+
+> See [decree#16](https://github.com/opendecree/decree/issues/16) for the org-wide attestation plan.
+
 ## Requirements
 
 - Python 3.11+


### PR DESCRIPTION
## Summary

- Set `attestations: true` in the `pypa/gh-action-pypi-publish` step — the existing `id-token: write` OIDC permission is already in place, so no further workflow changes are needed
- Added a **Supply Chain Security** section to README documenting how users can download and verify attestations with `pip download` + `gh attestation verify`
- Cross-referenced [decree#16](https://github.com/opendecree/decree/issues/16) (org-wide attestation plan)

## Test plan

- [ ] Verify the workflow YAML is valid (no lint errors)
- [ ] On the next tagged release, confirm attestations appear on the PyPI project page
- [ ] Run `gh attestation verify opendecree-*.whl --repo opendecree/decree-python` against the published wheel

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)