### PR TITLE
Add devcontainer config and Codespaces badge

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "OpenDecree Python SDK",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "charliermarsh.ruff",
+        "ms-python.mypy-type-checker"
+      ]
+    }
+  },
+  "postCreateCommand": "cd sdk && pip install -e '.[dev]'"
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/github/license/opendecree/decree-python)](LICENSE)
 [![Project Status: WIP](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![codecov](https://codecov.io/gh/opendecree/decree-python/graph/badge.svg)](https://codecov.io/gh/opendecree/decree-python)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/opendecree/decree-python)
 
 Python SDK for [OpenDecree](https://github.com/opendecree/decree) — schema-driven configuration management.
 


### PR DESCRIPTION
## Summary

- Adds a `.devcontainer/devcontainer.json` so contributors can spin up a fully configured Python 3.12 dev environment in GitHub Codespaces or any devcontainer-compatible editor without any manual setup.
- Installs all dev dependencies automatically via `pip install -e '.[dev]'` on container creation.
- Adds an "Open in GitHub Codespaces" badge to README.md to make the one-click setup path discoverable.

## Test plan

- [ ] Verify `.devcontainer/devcontainer.json` is valid JSON
- [ ] Open the repo in GitHub Codespaces and confirm the container builds with Python 3.12
- [ ] Confirm `make lint`, `make typecheck`, and `make test` all pass inside the container after postCreateCommand runs
- [ ] Confirm the Codespaces badge in README.md links to `https://codespaces.new/opendecree/decree-python`

Closes #9