### PR TITLE
docs: fix configuration.md ConfigValue references

### DIFF
--- a/sdk/docs/configuration.md
+++ b/sdk/docs/configuration.md
@@ -204,16 +204,10 @@ All exceptions inherit from `DecreeError`:
 
 ## Return types
 
-All return types are frozen dataclasses:
+`get_all()` returns a plain `dict[str, str]` mapping field paths to their string
+values — not a dataclass. The other typed return values are frozen dataclasses:
 
 ```python
-@dataclass(frozen=True, slots=True)
-class ConfigValue:
-    field_path: str
-    value: str
-    checksum: str
-    description: str
-
 @dataclass(frozen=True, slots=True)
 class Change:
     field_path: str
@@ -221,4 +215,9 @@ class Change:
     new_value: str | None
     version: int
     changed_by: str
+
+@dataclass(frozen=True, slots=True)
+class ServerVersion:
+    version: str
+    commit: str
 ```


### PR DESCRIPTION
## Summary
- The Return types section of configuration.md documented a `ConfigValue` dataclass (with `field_path`, `value`, `checksum`, `description` fields) that does not exist in the package — importing it raises an ImportError.
- Replace it with the real third dataclass, `ServerVersion` (`version`, `commit`), and clarify that `get_all()` returns a plain `dict[str, str]` mapping field paths to their string values rather than a dataclass.

## Test plan
- [x] Verified `ServerVersion`'s actual fields against `sdk/src/opendecree/types.py`
- [x] Verified `get_all()`'s actual return type (`dict[str, str]`) against `sdk/src/opendecree/client.py`
- [x] Ran the repo's pre-commit checklist (docs-only diff short-circuits to safety scan only)

Closes #134