### PR TITLE
docs: trim README badges to highest-signal set

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 [![CI](https://github.com/opendecree/decree-python/actions/workflows/ci.yml/badge.svg)](https://github.com/opendecree/decree-python/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/opendecree)](https://pypi.org/project/opendecree/)
-[![Python](https://img.shields.io/pypi/pyversions/opendecree)](https://pypi.org/project/opendecree/)
-[![Downloads](https://img.shields.io/pypi/dm/opendecree)](https://pypi.org/project/opendecree/)
 [![License](https://img.shields.io/github/license/opendecree/decree-python)](LICENSE)
-[![Project Status: WIP](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
-[![codecov](https://codecov.io/gh/opendecree/decree-python/graph/badge.svg)](https://codecov.io/gh/opendecree/decree-python)
 [![Docs](https://img.shields.io/badge/docs-opendecree.github.io-teal)](https://opendecree.github.io/decree-python)
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/opendecree/decree-python)
 


### PR DESCRIPTION
## Summary
- Reduce header badges to the 5 highest-signal: CI, PyPI, License, Docs, Codespaces.
- Drop Python-version, Downloads, repostatus "WIP", and codecov badges — Downloads is at zero pre-1.0 (vanity badge that undersells the project), and the Alpha note already covers status.

## Test plan
- [x] Visual check of remaining badge markup renders correctly