### PR TITLE
docs: re-add Coverage badge, Codespaces on its own line

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![PyPI](https://img.shields.io/pypi/v/opendecree)](https://pypi.org/project/opendecree/)
 [![License](https://img.shields.io/github/license/opendecree/decree-python)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-opendecree.github.io-teal)](https://opendecree.github.io/decree-python)
+[![codecov](https://codecov.io/gh/opendecree/decree-python/graph/badge.svg)](https://codecov.io/gh/opendecree/decree-python)
+
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/opendecree/decree-python)
 
 Python SDK for [OpenDecree](https://github.com/opendecree/decree) — schema-driven configuration management.


### PR DESCRIPTION
## Summary
- Follow-up to #143. Restore the codecov badge (cap raised to 6) as a quality signal.
- Move the "Open in GitHub Codespaces" badge to its own line at the end so it reads as a standalone call-to-action. Mirrors opendecree/decree#903.

## Test plan
- [x] Visual check of remaining badge markup renders correctly