### PR TITLE
chore: ignore protobuf 7.x updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # grpcio-tools 1.81.1 (latest) caps protobuf<7; unignore once a
+      # grpcio-tools release supports protobuf 7.x.
+      - dependency-name: "protobuf"
+        versions: [">=7"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

- Dependabot PR #150 bumped `protobuf` to `>=7.35.1,<8`, but `grpcio-tools` 1.81.1 (the latest release, used as a dev dependency for codegen/typecheck/tests) still requires `protobuf<7.0.0,>=6.33.5`. This makes the dependency set unresolvable and breaks Typecheck, Tests, and Examples in CI.
- Add a dependabot `ignore` rule for `protobuf >=7` in the `/sdk` and `/examples` pip ecosystem so we don't get repeated unresolvable bumps until `grpcio-tools` ships protobuf-7 support.

## Test plan

- [ ] CI passes on this PR
- [ ] Close dependabot PR #150 as not mergeable (blocked upstream)