### PR TITLE
ci(docs): add workflow_dispatch and Pages concurrency to docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,11 +4,16 @@ on:
   push:
     branches: [main]
     tags: ["v*.*.*"]
+  workflow_dispatch:
 
 permissions:
   contents: read
   pages: write
   id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Publishes the Python SDK docs to GitHub Pages, closing the last gap where Python
was the only SDK without a live docs site (Go on pkg.go.dev, TypeScript and the
Admin UI already publish).

**Root cause:** the `Deploy Docs` workflow built the site correctly, but every run
failed at the deploy step because **GitHub Pages was never enabled** on the
repository — `actions/deploy-pages` returned `404 ... Ensure GitHub Pages has been
enabled`. The mkdocs config, `make docs` target, deploy workflow, and README links
were all already in place; only the repo setting was missing.

**Resolution:**
- Enabled GitHub Pages with the **GitHub Actions** source (`build_type=workflow`)
  via the Pages API.
- Re-ran the `Deploy Docs` workflow; build and deploy jobs are now green and the
  site is live.
- Hardened the workflow (this PR's diff): added a `workflow_dispatch` trigger so the
  docs can be redeployed manually, and a `pages` concurrency group so overlapping
  deploys are serialized — mirroring `decree-typescript`.

## Test plan

- [x] `Deploy Docs` workflow succeeds end-to-end (build + deploy jobs green)
- [x] Live site returns 200: `/`, `/guide/connect/`, `/guide/watch/`, `/guide/async/`, `/api/`
- [x] Docs URL matches the README badge and Documentation section (`https://opendecree.github.io/decree-python`)
- [x] Workflow YAML validates (pre-commit)

Closes #165
