### PR TITLE
chore(deps): ignore grpcio-tools>=1.82.1 pending protobuf 7 migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,10 +16,15 @@ updates:
           - minor
           - patch
     ignore:
-      # grpcio-tools 1.81.1 (latest) caps protobuf<7; unignore once a
-      # grpcio-tools release supports protobuf 7.x.
+      # protobuf is capped <7 by our own pyproject.toml pin; unignore once we
+      # deliberately migrate the SDK to protobuf 7.x.
       - dependency-name: "protobuf"
         versions: [">=7"]
+      # grpcio-tools 1.82.1 raised its own floor to protobuf>=7.35.1,
+      # incompatible with our protobuf<7 pin (decree-python#174). Unignore
+      # together with the protobuf migration above.
+      - dependency-name: "grpcio-tools"
+        versions: [">=1.82.1"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

- grpcio-tools 1.82.1 raised its own floor to `protobuf>=7.35.1`, which conflicts with our `protobuf<7` pin in `sdk/pyproject.toml`. This broke CI on #174 (dependabot's grpcio-tools bump), which cannot merge until this is resolved.
- The existing dependabot ignore rule for `protobuf>=7` assumed a future grpcio-tools release would add protobuf 7.x support while retaining protobuf<7 compatibility. It didn't — 1.82.1 just moved its floor forward.
- Adds a matching ignore rule for `grpcio-tools>=1.82.1` so dependabot stops proposing bumps we can't take, until we deliberately migrate the SDK to protobuf 7.

## Test plan

- [x] Reviewed CI failure logs on #174 to confirm root cause (pip dependency resolution conflict)
- [x] Confirmed dependabot.yml syntax is valid YAML
- Not a code change — no tests affected

Refs #174